### PR TITLE
Increase PBKDF2 iterations to 200k

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
     async function deriveKey(pass, saltBytes){
       const baseKey = await crypto.subtle.importKey('raw', enc.encode(pass), 'PBKDF2', false, ['deriveKey']);
       return crypto.subtle.deriveKey(
-        { name:'PBKDF2', salt: saltBytes, iterations:100000, hash:'SHA-256' },
+        { name:'PBKDF2', salt: saltBytes, iterations:200000, hash:'SHA-256' },
         baseKey,
         { name:'AES-GCM', length:256 },
         false,


### PR DESCRIPTION
## Summary
- align PBKDF2 key derivation with documented 200k iteration count

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b38e0839208331835a4b5a9230ef2a