### PR TITLE
feat: add top margin for locked message

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
       top: var(--header-h);
       left: 0; right: 0;
       bottom: calc(var(--input-h) + env(safe-area-inset-bottom));
-      padding: 10px;
+      padding: 20px 10px 10px;
       overflow-y: auto;
       -webkit-overflow-scrolling: touch;
       box-sizing: border-box;


### PR DESCRIPTION
## Summary
- add extra top padding in terminal output so locked notice isn't flush against header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b39305befc833187a98a84b930862f