### PR TITLE
Add CLEAR command to clear terminal display

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Type commands into the input bar or directly in the terminal view.
 
 ### Security & Data
 - `stats` — summary counts
+- `clear` — clear the display
 - `export` — download JSON (tasks + notes)
 - `import` — paste JSON to replace all data
 - `wipe` — clear all data (with confirm)

--- a/index.html
+++ b/index.html
@@ -382,6 +382,7 @@
       println('  NSEARCH <query>           find text in notes');
       println('Security & Data:');
       println('  STATS                     summary counts');
+      println('  CLEAR                     clear the display');
       println('  EXPORT                    download JSON (tasks + notes)');
       println('  IMPORT                    paste JSON to replace all data');
       println('  WIPE                      clear all data (with confirm)');
@@ -562,6 +563,11 @@
     };
 
     // General
+    cmd.clear = ()=>{
+      output.innerHTML = '';
+      lastTaskListCache = null;
+      lastNoteListCache = null;
+    };
     cmd.stats = ()=>{
       const total = items.length;
       const done = items.filter(t=>t.done).length;
@@ -676,7 +682,7 @@
       const args = parts;
       const fn = cmd[name];
       if (!fn){ println('unknown command. type HELP.', 'error'); return; }
-      if (locked && !['unlock','help'].includes(name)){
+      if (locked && !['unlock','help','clear'].includes(name)){
         println('data locked. type UNLOCK.', 'error');
         return;
       }


### PR DESCRIPTION
## Summary
- add `CLEAR` command to wipe terminal output without locking app
- document `CLEAR` command in help text and README
- allow `CLEAR` when app is locked

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a4245f70833194acaed1ae085b34