### PR TITLE
feat: mask passcode input

### DIFF
--- a/index.html
+++ b/index.html
@@ -615,7 +615,7 @@
     cmd.setpass = async ()=>{
       if (locked){ println('unlock first', 'error'); return; }
       println('Enter new passcode (blank to disable):', 'muted');
-      const pass = await getNextLine();
+      const pass = await getNextLine(true);
       if (!pass){
         passKey = null; passSalt = null;
         await saveState(state);
@@ -649,7 +649,7 @@
         const obj = JSON.parse(raw);
         if (!obj.enc){ println('no passcode set','error'); return; }
         println('Enter passcode:', 'muted');
-        const pass = await getNextLine();
+        const pass = await getNextLine(true);
         const saltBytes = b64ToBuf(obj.enc.salt);
         const key = await deriveKey(pass, saltBytes);
         const iv = b64ToBuf(obj.enc.iv);
@@ -688,14 +688,16 @@
       }
       Promise.resolve(fn(args)).catch(err=>println('error: '+err.message,'error'));
     }
-    function getNextLine(){
+    function getNextLine(mask = false){
       awaitingLine = true;
+      if (mask) command.type = 'password';
       return new Promise(resolve => {
         function handler(e){
           if (e.key === 'Enter'){
             const val = command.value;
-            println('> ' + val);
+            println('> ' + (mask ? '*'.repeat(val.length) : val));
             command.value = '';
+            command.type = 'text';
             command.removeEventListener('keydown', handler);
             awaitingLine = false;
             resolve(val);


### PR DESCRIPTION
## Summary
- mask passcode entry when setting or unlocking
- add masking support to getNextLine for secure input

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aacaf5cc8331a3431642e0ece3ee