### PR TITLE
Allow command input suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,8 +140,8 @@
 
   <div id="input-bar" role="group" aria-label="Command input">
     <span id="prompt-label">&gt; </span>
-    <input id="command" type="text" inputmode="text" autocapitalize="none"
-           autocomplete="off" spellcheck="false" placeholder="enter command..." />
+    <input id="command" type="text" inputmode="text" autocapitalize="sentences"
+           autocomplete="new-password" spellcheck="true" placeholder="enter command..." />
   </div>
 
   <div id="modal" role="dialog" aria-modal="true" aria-labelledby="wipe-title">


### PR DESCRIPTION
## Summary
- Allow sentence capitalization and spellcheck on command input
- Relax autocomplete to avoid password/credit-card suggestions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3afb59fd08331ad0e6e9a870d240e