### PR TITLE
Disable credential autofill suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,8 +140,8 @@
 
   <div id="input-bar" role="group" aria-label="Command input">
     <span id="prompt-label">&gt; </span>
-    <input id="command" type="text" inputmode="text" autocapitalize="sentences"
-           spellcheck="true" placeholder="enter command..." />
+    <input id="command" name="command" type="text" inputmode="text" autocapitalize="sentences"
+           spellcheck="true" placeholder="enter command..." autocomplete="off" />
   </div>
 
   <div id="modal" role="dialog" aria-modal="true" aria-labelledby="wipe-title">


### PR DESCRIPTION
## Summary
- disable credential suggestions by setting command input's autocomplete to off

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b3b8cfb48331acbd8995b23fb513