### PR TITLE
Add command input history navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,6 +255,9 @@
     const output = document.getElementById('output');
     const command = document.getElementById('command');
     let awaitingLine = false;
+    const HISTORY_KEY = 'command-history';
+    let history = JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]');
+    let historyIndex = history.length;
     const modal = document.getElementById('modal');
     const btnCancel = document.getElementById('btn-cancel');
     const btnOK = document.getElementById('btn-confirm');
@@ -678,6 +681,9 @@
       const line = raw.trim();
       if (!line) return;
       println('> ' + line);
+      history.push(line);
+      historyIndex = history.length;
+      localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
       const parts = line.split(/\s+/);
       const name = parts.shift().toLowerCase();
       const args = parts;
@@ -708,6 +714,16 @@
       });
     }
     command.addEventListener('keydown', (e)=>{
+      if (!awaitingLine && (e.key === 'ArrowUp' || e.key === 'ArrowDown')){
+        if (e.key === 'ArrowUp'){
+          if (historyIndex > 0) historyIndex--;
+        } else {
+          if (historyIndex < history.length) historyIndex++;
+        }
+        command.value = history[historyIndex] || '';
+        e.preventDefault();
+        return;
+      }
       if (e.key === 'Enter'){
         if (awaitingLine) return;
         const v = command.value;


### PR DESCRIPTION
## Summary
- track command history and persist to localStorage
- allow navigating past commands with the up/down arrows

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c9daf77c8331826bf35ab2ccace2