### PR TITLE
feat: add theme command

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,6 +283,24 @@
 
     function saveItems(v){ state.items = v; saveState(state); }
     function saveNotes(v){ state.notes = v; saveState(state); }
+    const THEME_KEY = 'terminal-theme';
+    function applyTheme(t){
+      const root = document.documentElement.style;
+      root.setProperty('--bg', t.bg);
+      root.setProperty('--fg', t.fg);
+      root.setProperty('--border', t.border);
+    }
+    function loadTheme(){
+      try{
+        return JSON.parse(localStorage.getItem(THEME_KEY));
+      }catch{}
+      return null;
+    }
+    function saveTheme(t){
+      localStorage.setItem(THEME_KEY, JSON.stringify(t));
+    }
+    const savedTheme = loadTheme();
+    if (savedTheme) applyTheme(savedTheme);
 
     /************
      * UI HELPERS
@@ -446,6 +464,8 @@
       println('  SETPASS                   set or clear passcode');
       println('  LOCK                      clear decrypted data from memory');
       println('  UNLOCK                    restore data with passcode');
+      println('Appearance:');
+      println('  THEME <bg> <fg> <border>   set colors');
     };
 
     let lastTaskListCache = null;
@@ -643,6 +663,16 @@
       const noteCount = notes.length;
       println(`Tasks — Total: ${total}  Open: ${open}  Done: ${done}`);
       println(`Notes — Total: ${noteCount}`);
+    };
+    cmd.theme = (args)=>{
+      if (args.length !== 3){
+        println('usage: THEME <bg> <fg> <border>', 'error');
+        return;
+      }
+      const [bg, fg, border] = args;
+      applyTheme({ bg, fg, border });
+      saveTheme({ bg, fg, border });
+      println('theme updated.', 'ok');
     };
     function download(filename, text) {
       const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- add THEME command for custom colors
- persist theme selection to localStorage
- document THEME usage in help output

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b3ccf806248331bc4bfaaf9971d309