### PR TITLE
feat: add gdrive credential configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Type commands into the input bar or directly in the terminal view.
 - `aquery <query>` — run an advanced task query (tag/due/done/pri filters; `due:overdue` for past-due tasks)
 - `nrich <id|#> <title>|[body]|[link]` — edit note with rich fields
 - `backup [provider] [upload|download]` — sync data to a sandbox provider (`local` or `gdrive`)
+- `gdriveconfig <client_id> <api_key>` — store Google Drive credentials for backup
 - `themepreset <json>` — apply a theme preset from JSON
 - `themeexport [name]` — download current theme preset
 - `collab <session>` — join a collaboration channel and broadcast tasks/notes
@@ -144,15 +145,17 @@ TerminalListFeatures.editNoteRich(noteId, {
 ```js
 await TerminalListFeatures.syncWithCloud('local', 'upload');   // save to localStorage sandbox
 await TerminalListFeatures.syncWithCloud('local', 'download'); // restore from sandbox
+```
 
-// Google Drive (requires API key & client ID in features.js)
+### Google Drive Backup
+Run inside the app:
+```
+GDRIVECONFIG <client_id> <api_key>
+```
+Then:
+```js
 await TerminalListFeatures.syncWithCloud('gdrive', 'upload');
 await TerminalListFeatures.syncWithCloud('gdrive', 'download');
-=======
-### Local "Cloud" Backup
-```js
-await TerminalListFeatures.syncWithCloud('local', 'upload');   // save to localStorage sandbox
-await TerminalListFeatures.syncWithCloud('local', 'download'); // restore from sandbox
 ```
 
 ### Theme Presets

--- a/features.js
+++ b/features.js
@@ -94,22 +94,33 @@ function editNoteRich(noteId, options = {}) {
 
 // --- Cloud Backup / Sync --------------------------------------------------
 
-const GDRIVE_CLIENT_ID = 'YOUR_CLIENT_ID.apps.googleusercontent.com';
-const GDRIVE_API_KEY = 'YOUR_API_KEY';
+const GDRIVE_CLIENT_ID_KEY = 'terminal-list-gdrive-client-id';
+const GDRIVE_API_KEY_KEY = 'terminal-list-gdrive-api-key';
 const GDRIVE_SCOPES = 'https://www.googleapis.com/auth/drive.file';
 let gdriveInitPromise = null;
+
+function getGDriveClientId() {
+  return localStorage.getItem(GDRIVE_CLIENT_ID_KEY);
+}
+
+function getGDriveApiKey() {
+  return localStorage.getItem(GDRIVE_API_KEY_KEY);
+}
 
 function initGDrive() {
   if (!gdriveInitPromise) {
     gdriveInitPromise = new Promise((resolve, reject) => {
-      if (!window.gapi) return reject('gapi-not-loaded');
+      if (!window.gapi) { gdriveInitPromise = null; return reject('gapi-not-loaded'); }
+      const clientId = getGDriveClientId();
+      const apiKey = getGDriveApiKey();
+      if (!clientId || !apiKey) { gdriveInitPromise = null; return reject('gdrive credentials missing'); }
       gapi.load('client:auth2', () => {
         gapi.client.init({
-          apiKey: GDRIVE_API_KEY,
-          clientId: GDRIVE_CLIENT_ID,
+          apiKey,
+          clientId,
           discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'],
           scope: GDRIVE_SCOPES,
-        }).then(() => resolve(), reject);
+        }).then(resolve, err => { gdriveInitPromise = null; reject(err); });
       });
     });
   }

--- a/index.html
+++ b/index.html
@@ -492,6 +492,7 @@
       println('  THEME <bg> <fg> <border>   set colors');
       println('  THEMEPRESET <json>        apply theme preset');
       println('  THEMEEXPORT [name]        export current theme');
+      println('  GDRIVECONFIG <client_id> <api_key>  set Google Drive credentials');
       println('  BACKUP [provider] [upload|download] sync data');
       println('  COLLAB <session>          start collaboration channel');
     };
@@ -780,6 +781,18 @@
       const name = args[0] || 'theme';
       TerminalListFeatures.exportThemePreset(name);
       println('theme exported.', 'ok');
+    };
+
+    cmd.gdriveconfig = (args)=>{
+      const clientId = args[0];
+      const apiKey = args[1];
+      if (!clientId || !apiKey){
+        println('usage: GDRIVECONFIG <client_id> <api_key>', 'error');
+        return;
+      }
+      localStorage.setItem('terminal-list-gdrive-client-id', clientId);
+      localStorage.setItem('terminal-list-gdrive-api-key', apiKey);
+      println('gdrive credentials saved.', 'ok');
     };
 
     cmd.backup = (args)=>{


### PR DESCRIPTION
## Summary
- add `GDRIVECONFIG` command to save Google Drive keys in localStorage
- pull Drive credentials from storage and validate before init
- update docs to describe Drive backup setup workflow

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b468f8a5b08331befbcf4a64d5e211