### PR TITLE
Add SYNTAX command and clarify rich note editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Type commands into the input bar or directly in the terminal view.
 
 ### Other
 
+- `syntax <command>` — show detailed usage for a command (e.g., `syntax nrich`)
 - `theme <bg> <fg> <border>` — set terminal colors
 
 ### Experimental Feature Commands
@@ -109,7 +110,7 @@ Type commands into the input bar or directly in the terminal view.
 - `recur <id|#> <n> <unit>` — schedule recurring reminder (`unit` = minute|hour|day|week)
 - `snooze <id|#> <YYYY-MM-DD>` — snooze a task to a new date
 - `aquery <query>` — run an advanced task query (tag/due/done/pri filters; `due:overdue` for past-due tasks)
-- `nrich <id|#> <title>|[body]|[link]` — edit note with rich fields
+- `nrich <id|#> <title>|[body]|[link]|[attachments]` — edit note with rich fields; attachments are a comma-separated list of URLs or data URIs
 - `backup [provider] [upload|download]` — sync data to a sandbox provider (`local` or `gdrive`)
 - `gdriveconfig <client_id> <api_key>` — store Google Drive credentials for backup
 - `themepreset <json>` — apply a theme preset from JSON

--- a/index.html
+++ b/index.html
@@ -453,6 +453,9 @@
      ************/
     const cmd = {};
     cmd.help = () => {
+      println('General:');
+      println('  SYNTAX <command>          show command syntax');
+      println('');
       println('Tasks:');
       println('  ADD <text>                add a new item');
       println('  LIST [all|open|done|@tag] [--sort=due|pri] list items');
@@ -473,7 +476,7 @@
       println('  NOTE <title>|<desc>|[link]|[body] add a note');
       println('  NOTES [all|@tag|task:<ref>] list notes');
       println('  NEDIT <id|#> <title>|<desc>|[link]|[body] edit a note');
-      println('  NRICH <id|#> <title>|[body]|[link] rich edit a note');
+      println('  NRICH <id|#> <title>|[body]|[link]|[attachments] rich edit a note');
       println('  NDELETE <id|#>            delete a note');
       println('  NLINK <note|#> <task|#>   link a note to a task');
       println('  NUNLINK <note|#>          unlink note from task');
@@ -687,11 +690,12 @@
       const n = resolveNoteRef(ref, lastNoteListCache);
       if (!n) return println('not found', 'error');
       const parts = args.join(' ').split('|').map(s=>s.trim());
-      const [title, body, link] = parts;
+      const [title, body, link, attach] = parts;
       TerminalListFeatures.editNoteRich(n.id, {
         title: title || n.title,
         body: body || n.body,
-        links: link ? [link] : n.links
+        links: link ? [link] : (n.links || []),
+        attachments: attach ? attach.split(',').map(s=>s.trim()).filter(Boolean) : (n.attachments || [])
       });
       println('note updated.', 'ok'); printNote(n);
     };
@@ -735,12 +739,39 @@
       println('Description: ' + (n.description || ''));
       println('Link: ' + (n.link || ''));
       println('Body: ' + (n.body || n.text || ''));
+      const atts = (n.attachments || []).join(', ');
+      println('Attachments: ' + (atts || ''));
       const tags = (n.tags||[]).map(t=>'@'+t).join(' ');
       println('Tags: ' + tags);
       println('Linked Task: ' + (n.taskId || ''));
     };
 
     // General
+    cmd.syntax = (args)=>{
+      const topic = (args[0] || '').toLowerCase();
+      const info = {
+        nrich: [
+          'NRICH <id|#> <title>|[body]|[link]|[attachments]',
+          '  Rich edit a note; fields separated by "|".',
+          '  title        new title (optional)',
+          '  body         note body (optional)',
+          '  link         URL or note:<id> (optional)',
+          '  attachments  comma-separated URLs or data URIs (optional)'
+        ],
+        note: [
+          'NOTE <title>|<desc>|[link]|[body]',
+          '  Create a note; fields separated by "|".',
+          '  link and body are optional.',
+          '  Use NRICH to add attachments later.'
+        ]
+      };
+      if (!topic || !info[topic]) {
+        println('usage: SYNTAX <command>', 'muted');
+        println('available: ' + Object.keys(info).map(k=>k.toUpperCase()).join(', '), 'muted');
+        return;
+      }
+      info[topic].forEach(line => println(line));
+    };
     cmd.clear = ()=>{
       output.innerHTML = '';
       lastTaskListCache = null;


### PR DESCRIPTION
## Summary
- add `SYNTAX` command for in-app syntax reference and show it in HELP output
- expand `NRICH` to handle attachments and display them with READNOTE
- document `syntax` usage and rich note attachments in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b46fefb35c8331a3131d9556501be5