### PR TITLE
Expose notes for feature helpers

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,6 +263,8 @@
       };
     });
     state.notes = notes;
+    // expose notes array for feature helpers
+    window.notes = notes;
     if (needsNoteMigration) saveNotes(notes);
 
     // Service Worker registration and notification timers
@@ -301,7 +303,12 @@
     }
 
     function saveItems(v){ state.items = v; saveState(state); }
-    function saveNotes(v){ state.notes = v; saveState(state); }
+    function saveNotes(v){
+      notes = v;
+      window.notes = v;
+      state.notes = v;
+      saveState(state);
+    }
     const THEME_KEY = 'terminal-theme';
     function applyTheme(t){
       const root = document.documentElement.style;


### PR DESCRIPTION
## Summary
- expose notes array globally for feature helpers
- keep notes, window.notes, and state in sync when saving

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b476413d8883318f13c2787bd9ef65