### PR TITLE
Add note tagging command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It supports optional passcode protection with AES-256 encryption, JSON export/im
 ## Features
 
 - ✅ **Tasks**: Add items, tag them, set priorities or due dates, and search.
-- 📝 **Notes**: Create standalone notes or link them to tasks.
+- 📝 **Notes**: Create standalone notes or link them to tasks, and tag them.
 - 🔐 **Passcode Lock**: Protect your data with AES-256-GCM encryption (derived with PBKDF2).
 - ⏰ **Due-date Notifications**: Receive reminders for tasks on their due date (requires notification permission).
 - 🎨 **Custom Themes**: Adjust terminal colors with the `THEME` command.
@@ -68,7 +68,7 @@ Type commands into the input bar or directly in the terminal view.
 
 ### Tasks
 - `add <text>` — add a new item
-- `list [all|open|done|@tag]` — list items
+- `list [all|open|done|@tag]` — list items; when using `@tag` notes are also shown
 - `show <id|#>` — show a task with attached notes
 - `done <id|#>` — mark done
 - `undone <id|#>` — unmark done
@@ -90,6 +90,7 @@ Type commands into the input bar or directly in the terminal view.
 - `ndelete <id|#>` — delete a note
 - `nlink <note|#> <task|#>` — link a note to a task
 - `nunlink <note|#>` — unlink note from task
+- `ntag <id|#> +foo -bar` — add/remove tags
 - `nsearch <query>` — find text in notes
 
 ### Security & Data

--- a/index.html
+++ b/index.html
@@ -660,7 +660,7 @@
       println('');
       println('Tasks:');
       println('  ADD <text>                add a new item');
-      println('  LIST [all|open|done|@tag] [--sort=due|pri] list items');
+      println('  LIST [all|open|done|@tag] [--sort=due|pri] list items; @tag also shows notes');
       println('  SHOW <id|#>               show a task with attached notes');
       println('  DONE <id|#>               mark done');
       println('  UNDONE <id|#>             unmark done');
@@ -682,6 +682,7 @@
       println('  NDELETE <id|#>            delete a note');
       println('  NLINK <note|#> <task|#>   link a note to a task');
       println('  NUNLINK <note|#>          unlink note from task');
+      println('  NTAG <id|#> +foo -bar     add/remove tags');
       println('  READNOTE <id|#>          show note details');
       println('  SEEPIC <id|#>            view note image');
       println('  DLPIC <id|#>             download note image');
@@ -722,6 +723,12 @@
       let title = 'LIST ' + filter.toUpperCase();
       if (sortBy) title += ' SORTED BY ' + sortBy.toUpperCase();
       printList(lastTaskListCache, title);
+      if (filter.startsWith('@')) {
+        lastNoteListCache = listFilteredNotes(filter);
+        printNotes(lastNoteListCache, 'NOTES ' + filter.toUpperCase());
+      } else {
+        lastNoteListCache = null;
+      }
     };
     cmd.show = (args)=>{
       const ref = args[0];
@@ -910,6 +917,24 @@
       n.taskId = null; n.updatedAt = Date.now(); saveNotes(notes);
       println('note unlinked.', 'ok'); printNote(n);
     };
+    cmd.ntag = (args)=>{
+      const ref = args.shift();
+      const n = resolveNoteRef(ref, lastNoteListCache);
+      if (!n) return println('not found', 'error');
+      n.tags = n.tags || [];
+      for (const tok of args){
+        if (tok.startsWith('+')){
+          const tag = tok.slice(1);
+          if (!n.tags.includes(tag)) n.tags.push(tag);
+        } else if (tok.startsWith('-')){
+          const tag = tok.slice(1);
+          n.tags = n.tags.filter(x=>x!==tag);
+        }
+      }
+      n.updatedAt = Date.now();
+      saveNotes(notes);
+      println('tags updated.', 'ok'); printNote(n);
+    };
     cmd.nsearch = (args)=>{
       const q = args.join(' ').toLowerCase();
       if (!q) return println('usage: NSEARCH <query>', 'error');
@@ -1014,6 +1039,10 @@
         dlpic: [
           'DLPIC <id|#>',
           '  Download first image attachment of note'
+        ],
+        ntag: [
+          'NTAG <id|#> +foo -bar',
+          '  Add (+) or remove (-) tags from a note'
         ]
       };
       if (!topic || !info[topic]) {


### PR DESCRIPTION
## Summary
- Add `NTAG` command to apply or remove tags on notes
- Show notes alongside tasks when listing by tag
- Document note tagging and cross-tag listing in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a42986708331b46874684b3c279d