### PR TITLE
Add READMSG command to view messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Type commands into the input bar or directly in the terminal view.
 - `msgs` — list messages
 - `sendmsg` — compose and share an encrypted message
 - `recmsg` — paste shared message JSON and decrypt with a passcode
+- `readmsg <id|#>` — read a message
 - `replymsg <id|#>` — reply to a message
 - `delmsg <id|#>` — delete a message
 

--- a/index.html
+++ b/index.html
@@ -783,6 +783,7 @@
       println('  MSGS                     list messages');
       println('  SENDMSG                  compose and share a message');
       println('  RECMSG                   receive a shared message');
+      println('  READMSG <id|#>          read a message');
       println('  REPLYMSG <id|#>          reply to a message');
       println('  DELMSG <id|#>           delete a message');
       println('Security & Data:');
@@ -1175,6 +1176,24 @@
         println('import failed: ' + e.message, 'error');
       }
     };
+    cmd.readmsg = (args)=>{
+      const ref = args[0];
+      const m = resolveMessageRef(ref, lastMsgListCache);
+      if (!m) return println('not found', 'error');
+      println('(' + m.id + ')');
+      println('From: ' + (m.from || ''));
+      println('To: ' + (m.to || ''));
+      println('Subject: ' + (m.subject || ''));
+      println('Date: ' + (m.date || '') + ' ' + (m.time || ''));
+      println('Message: ' + (m.message || ''));
+      const div = document.createElement('div');
+      div.className = 'line';
+      const btn = document.createElement('button');
+      btn.textContent = 'Reply';
+      btn.addEventListener('click', ()=>parseAndRun('REPLYMSG ' + m.id));
+      div.appendChild(btn);
+      output.appendChild(div);
+    };
     cmd.replymsg = (args)=>{
       const ref = args[0];
       const m = resolveMessageRef(ref, lastMsgListCache);
@@ -1239,6 +1258,10 @@
         recmsg: [
           'RECMSG',
           '  Paste shared message JSON, then enter its passcode'
+        ],
+        readmsg: [
+          'READMSG <id|#>',
+          '  Read a message'
         ],
         replymsg: [
           'REPLYMSG <id|#>',


### PR DESCRIPTION
## Summary
- Introduce `READMSG` command to display message details with a reply button invoking `REPLYMSG`
- Document new `READMSG` command in in-app help and README

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b9ccc918833195ad7ea928693934