### PR TITLE
warn to set passcode when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,10 @@ collab.broadcast(); // sync current tasks/notes to other tabs with same session
 
 ## Security Notes
 
-- If no passcode is set, data is saved in browser localStorage unencrypted.  
-- If a passcode is set, all data is encrypted at rest using AES-256-GCM.  
-- Passcode derivation uses PBKDF2 with 200k iterations.  
+- If no passcode is set, data is saved in browser localStorage unencrypted.
+- On startup, the app warns you when no passcode exists and recommends running `setpass` to protect your data.
+- If a passcode is set, all data is encrypted at rest using AES-256-GCM.
+- Passcode derivation uses PBKDF2 with 200k iterations.
 - Remember your passcode! Without it, encrypted data cannot be recovered.
 
 ## License

--- a/index.html
+++ b/index.html
@@ -1771,6 +1771,7 @@
       println('Type HELP for tasks, notes, and messages commands.');
       localStorage.setItem('terminal-list-initialized-v4','1');
     }
+    if (!passSalt) println('No passcode set. Use SETPASS to protect stored data.', 'error');
     if (locked) println('Data is locked. Type UNLOCK to access.', 'muted');
 
     // Focus on output tap


### PR DESCRIPTION
## Summary
- warn users on startup if no passcode is configured
- document warning behavior in security notes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dbe4b8f48331959589d1a2012a8e