### PR TITLE
Use in-memory store for Google Drive credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Run inside the app:
 ```
 GDRIVECONFIG <client_id> <api_key>
 ```
+> Credentials are held only for the current session and are not saved to storage. Re-enter them after each reload and keep these keys private.
 Then:
 ```js
 await TerminalListFeatures.syncWithCloud('gdrive', 'upload');
@@ -195,6 +196,7 @@ collab.broadcast(); // sync current tasks/notes to other tabs with same session
 - If a passcode is set, all data is encrypted at rest using AES-256-GCM.
 - Passcode derivation uses PBKDF2 with 200k iterations.
 - Remember your passcode! Without it, encrypted data cannot be recovered.
+- Google Drive credentials configured via `GDRIVECONFIG` live only in memory; never commit API keys or share them publicly.
 
 ## License
 

--- a/features.js
+++ b/features.js
@@ -96,17 +96,23 @@ function editNoteRich(noteId, options = {}) {
 
 // --- Cloud Backup / Sync --------------------------------------------------
 
-const GDRIVE_CLIENT_ID_KEY = 'terminal-list-gdrive-client-id';
-const GDRIVE_API_KEY_KEY = 'terminal-list-gdrive-api-key';
+// Store Google Drive credentials only in memory to avoid persisting
+// sensitive API keys in localStorage.
+let gdriveCredentials = { clientId: null, apiKey: null };
 const GDRIVE_SCOPES = 'https://www.googleapis.com/auth/drive.file';
 let gdriveInitPromise = null;
 
+function setGDriveCredentials(clientId, apiKey) {
+  gdriveCredentials.clientId = clientId;
+  gdriveCredentials.apiKey = apiKey;
+}
+
 function getGDriveClientId() {
-  return localStorage.getItem(GDRIVE_CLIENT_ID_KEY);
+  return gdriveCredentials.clientId;
 }
 
 function getGDriveApiKey() {
-  return localStorage.getItem(GDRIVE_API_KEY_KEY);
+  return gdriveCredentials.apiKey;
 }
 
 function initGDrive() {
@@ -275,6 +281,7 @@ window.TerminalListFeatures = {
   syncWithCloud,
   applyThemePreset,
   exportThemePreset,
-  startCollaboration
+  startCollaboration,
+  setGDriveCredentials
 };
 

--- a/index.html
+++ b/index.html
@@ -1336,9 +1336,8 @@
         println('usage: GDRIVECONFIG <client_id> <api_key>', 'error');
         return;
       }
-      localStorage.setItem('terminal-list-gdrive-client-id', clientId);
-      localStorage.setItem('terminal-list-gdrive-api-key', apiKey);
-      println('gdrive credentials saved.', 'ok');
+      TerminalListFeatures.setGDriveCredentials(clientId, apiKey);
+      println('gdrive credentials stored for this session. Keep your keys secure.', 'ok');
     };
 
     cmd.backup = (args)=>{


### PR DESCRIPTION
## Summary
- Keep Google Drive client ID and API key only in memory to avoid persisting sensitive credentials
- Update `GDRIVECONFIG` command to rely on in-memory credentials and warn users to secure their keys
- Document safe handling of API keys in README

## Testing
- `node --check features.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ddc2b8948331b662ec6e9b15e248