### PR TITLE
Reset messages on lock

### DIFF
--- a/index.html
+++ b/index.html
@@ -1455,8 +1455,8 @@
     cmd.lock = ()=>{
       if (locked){ println('already locked','muted'); return; }
       if (!passSalt){ println('no passcode set','error'); return; }
-      items = []; notes = [];
-      state.items = items; state.notes = notes;
+      items = []; notes = []; messages = [];
+      state.items = items; state.notes = notes; state.messages = messages;
       passKey = null;
       locked = true;
       lastTaskListCache = null; lastNoteListCache = null;


### PR DESCRIPTION
## Summary
- Reset the global `messages` array when locking the app to prevent residual data after logout.
- Update `state.messages` alongside items and notes before reloading.

## Testing
- ⚠️ `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e4b198bc833186f8bbdd1aaf628a