### PR TITLE
Block saving until passcode choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It supports optional passcode protection with AES-256 encryption, JSON export/im
 
 - ✅ **Tasks**: Add items, tag them, set priorities or due dates, and search.
 - 📝 **Notes**: Create standalone notes or link them to tasks, and tag them.
-- 🔐 **Passcode Lock**: Protect your data with AES-256-GCM encryption (derived with PBKDF2).
+- 🔐 **Passcode Lock**: Protect your data with AES-256-GCM encryption (derived with PBKDF2). Saving is blocked until you set a passcode or explicitly opt out with `nopass`.
 - ⏰ **Due-date Notifications**: Receive reminders for tasks on their due date (requires notification permission).
 - 🎨 **Custom Themes**: Adjust terminal colors with the `THEME` command.
 - 📤 **Export/Import**: Backup or restore tasks, notes, and messages in JSON format.
@@ -113,6 +113,7 @@ Type commands into the input bar or directly in the terminal view.
 - `importshare` — paste shared item JSON and decrypt with a passcode
 - `wipe` — clear all data (with confirm)
 - `setpass` — set or clear passcode
+- `nopass` — allow saving without a passcode
 - `lock` — clear decrypted data from memory
 - `unlock` — restore data with passcode
 
@@ -191,8 +192,8 @@ await collab.broadcast(); // sync current tasks/notes to other tabs with same se
 
 ## Security Notes
 
-- If no passcode is set, data is saved in browser localStorage unencrypted.
-- On startup, the app warns you when no passcode exists and recommends running `setpass` to protect your data.
+- On startup, the app blocks saving until you run `setpass` or explicitly decline with `nopass`.
+- If `nopass` is used, data is saved in browser localStorage unencrypted.
 - If a passcode is set, all data is encrypted at rest using AES-256-GCM.
 - Passcode derivation uses PBKDF2 with 200k iterations.
 - Remember your passcode! Without it, encrypted data cannot be recovered.

--- a/index.html
+++ b/index.html
@@ -254,6 +254,7 @@
      ************/
     const STORE_KEY_V2 = 'terminal-list-state-v2'; // {items:[], notes:[], messages:[]} or {version,enc:{}}
     const STORE_KEY_V1 = 'terminal-list-items-v1'; // legacy items-only
+    const PASS_DECLINED_KEY = 'terminal-pass-declined-v1';
 
     const enc = new TextEncoder();
     const dec = new TextDecoder();
@@ -291,6 +292,8 @@
     let passKey = null; // CryptoKey when unlocked
     let passSalt = null; // base64 string
     let locked = false;
+    let passDeclined = localStorage.getItem(PASS_DECLINED_KEY) === '1';
+    let savingBlocked = !passDeclined;
 
     function loadState(){
       try{
@@ -320,6 +323,7 @@
       return { items: [], notes: [], messages: [] };
     }
     async function saveState(state){
+      if (savingBlocked) return;
       try{
         if (passKey){
           const iv = crypto.getRandomValues(new Uint8Array(12));
@@ -355,6 +359,7 @@
     state.notes = notes;
     // expose notes array for feature helpers
     window.notes = notes;
+    savingBlocked = !passSalt && !passDeclined;
     if (needsNoteMigration) saveNotes(notes);
     let messages = state.messages || [];
     state.messages = messages;
@@ -795,6 +800,7 @@
       println('  IMPORTSHARE              paste shared item JSON to import');
       println('  WIPE                      clear all data (with confirm)');
       println('  SETPASS                   set or clear passcode');
+      println('  NOPASS                    save without passcode');
       println('  LOCK                      clear decrypted data from memory');
       println('  UNLOCK                    restore data with passcode');
       println('Appearance:');
@@ -1441,6 +1447,9 @@
       const pass = await getNextLine(true);
       if (!pass){
         passKey = null; passSalt = null;
+        localStorage.setItem(PASS_DECLINED_KEY, '1');
+        passDeclined = true;
+        savingBlocked = false;
         await saveState(state);
         println('passcode cleared.', 'ok');
         return;
@@ -1448,8 +1457,20 @@
       const saltBytes = crypto.getRandomValues(new Uint8Array(16));
       passSalt = b64(saltBytes);
       passKey = await deriveKey(pass, saltBytes);
+      localStorage.removeItem(PASS_DECLINED_KEY);
+      passDeclined = false;
+      savingBlocked = false;
       await saveState(state);
       println('passcode set.', 'ok');
+    };
+
+    cmd.nopass = ()=>{
+      if (passSalt){ println('passcode already set','muted'); return; }
+      localStorage.setItem(PASS_DECLINED_KEY, '1');
+      passDeclined = true;
+      savingBlocked = false;
+      saveState(state);
+      println('saving without passcode.', 'ok');
     };
 
     cmd.lock = ()=>{
@@ -1772,7 +1793,7 @@
       println('Type HELP for tasks, notes, and messages commands.');
       localStorage.setItem('terminal-list-initialized-v4','1');
     }
-    if (!passSalt) println('No passcode set. Use SETPASS to protect stored data.', 'error');
+    if (!passSalt && !passDeclined) println('No passcode set. Use SETPASS to protect stored data or NOPASS to save unencrypted. Saving disabled until a choice is made.', 'error');
     if (locked) println('Data is locked. Type UNLOCK to access.', 'muted');
 
     // Focus on output tap


### PR DESCRIPTION
## Summary
- Block state persistence until user sets a passcode or explicitly declines
- Add NOPASS command and update help text
- Document passcode choice requirement in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e53d30b48331bdda5abc4d66d211