### PR TITLE
refactor: convert features helpers to ES module

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,23 +137,26 @@ Type commands into the input bar or directly in the terminal view.
 
 ## Feature Helpers
 
-A global `TerminalListFeatures` object exposes experimental helpers, implemented in `features.js`. Invoke these from the browser console.
+Experimental helpers live in `features.js` and are exported as named functions. Import the helpers you need in your own scripts or from the browser console using `import('./features.js')`.
 
 ### Recurring & Snoozeable Reminders
 ```js
-TerminalListFeatures.scheduleRecurringReminder(taskId, { every: 1, unit: 'day' });
-TerminalListFeatures.snoozeReminder(taskId, '2024-05-20');
+import { scheduleRecurringReminder, snoozeReminder } from './features.js';
+scheduleRecurringReminder(taskId, { every: 1, unit: 'day' });
+snoozeReminder(taskId, '2024-05-20');
 ```
 
 ### Advanced Queries
 ```js
+import { parseAdvancedQuery } from './features.js';
 // returns matching task IDs
-TerminalListFeatures.parseAdvancedQuery('tag:work pri:H due:overdue done:false');
+parseAdvancedQuery('tag:work pri:H due:overdue done:false');
 ```
 
 ### Rich Note Editing
 ```js
-TerminalListFeatures.editNoteRich(noteId, {
+import { editNoteRich } from './features.js';
+editNoteRich(noteId, {
   title: 'Updated note',
   attachments: ['https://example.com/file.png'],
   links: ['note:2']
@@ -162,8 +165,9 @@ TerminalListFeatures.editNoteRich(noteId, {
 
 ### Cloud Backup
 ```js
-await TerminalListFeatures.syncWithCloud('local', 'upload');   // save to localStorage sandbox
-await TerminalListFeatures.syncWithCloud('local', 'download'); // restore from sandbox
+import { syncWithCloud } from './features.js';
+await syncWithCloud('local', 'upload');   // save to localStorage sandbox
+await syncWithCloud('local', 'download'); // restore from sandbox
 ```
 
 ### Google Drive Backup
@@ -174,19 +178,22 @@ GDRIVECONFIG <client_id> <api_key>
 > Credentials are held only for the current session and are not saved to storage. Re-enter them after each reload and keep these keys private.
 Then:
 ```js
-await TerminalListFeatures.syncWithCloud('gdrive', 'upload');
-await TerminalListFeatures.syncWithCloud('gdrive', 'download');
+import { syncWithCloud } from './features.js';
+await syncWithCloud('gdrive', 'upload');
+await syncWithCloud('gdrive', 'download');
 ```
 
 ### Theme Presets
 ```js
-TerminalListFeatures.applyThemePreset({ bg:'#000', fg:'#0f0', border:'#0f0' });
-TerminalListFeatures.exportThemePreset('my-theme'); // downloads my-theme.json
+import { applyThemePreset, exportThemePreset } from './features.js';
+applyThemePreset({ bg:'#000', fg:'#0f0', border:'#0f0' });
+exportThemePreset('my-theme'); // downloads my-theme.json
 ```
 
 ### Collaboration Channel
 ```js
-const collab = TerminalListFeatures.startCollaboration('session1', 'shared-secret');
+import { startCollaboration } from './features.js';
+const collab = startCollaboration('session1', 'shared-secret');
 await collab.broadcast(); // sync current tasks/notes to other tabs with same session and secret
 ```
 

--- a/features.js
+++ b/features.js
@@ -338,8 +338,8 @@ function startCollaboration(sessionId, secret, saltBytes) {
   return { channel, broadcast, getSalt: () => Array.from(salt || []) };
 }
 
-// Expose features for external use
-window.TerminalListFeatures = {
+// Named exports for feature helpers
+export {
   scheduleRecurringReminder,
   snoozeReminder,
   parseAdvancedQuery,

--- a/index.html
+++ b/index.html
@@ -247,8 +247,9 @@
   <!-- Update hash: curl -s https://apis.google.com/js/api.js | openssl dgst -sha384 -binary | openssl base64 -A -->
   <script src="https://apis.google.com/js/api.js" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous"></script>
 
-  <script src="features.js"></script>
-  <script>
+  <script type="module" src="features.js"></script>
+  <script type="module">
+    import { scheduleRecurringReminder, snoozeReminder, parseAdvancedQuery, applyThemePreset, exportThemePreset, setGDriveCredentials, syncWithCloud, startCollaboration } from './features.js';
     /************
      * STORAGE
      ************/
@@ -954,7 +955,7 @@
       if (!t || !every || !unit){
         return println('usage: RECUR <id|#> <n> <minute|hour|day|week>', 'error');
       }
-      TerminalListFeatures.scheduleRecurringReminder(t.id, { every, unit });
+      scheduleRecurringReminder(t.id, { every, unit });
       println('recurrence scheduled.', 'ok');
     };
 
@@ -964,7 +965,7 @@
       if (!t || !until){
         return println('usage: SNOOZE <id|#> <YYYY-MM-DD>', 'error');
       }
-      TerminalListFeatures.snoozeReminder(t.id, until);
+      snoozeReminder(t.id, until);
       println('snoozed.', 'ok');
       printTask(t);
     };
@@ -972,7 +973,7 @@
     cmd.aquery = (args)=>{
       const q = args.join(' ');
       if (!q) return println('usage: AQUERY <query>', 'error');
-      const ids = TerminalListFeatures.parseAdvancedQuery(q);
+      const ids = parseAdvancedQuery(q);
       const hits = items.filter(t=> ids.includes(t.id));
       printList(hits, 'ADV QUERY: ' + q);
     };
@@ -1323,7 +1324,7 @@
       if (!json) return println('usage: THEMEPRESET <json>', 'error');
       try {
         const preset = JSON.parse(json);
-        TerminalListFeatures.applyThemePreset(preset);
+        applyThemePreset(preset);
         println('theme preset applied.', 'ok');
       } catch(e){
         println('invalid preset', 'error');
@@ -1332,7 +1333,7 @@
 
     cmd.themeexport = (args)=>{
       const name = args[0] || 'theme';
-      TerminalListFeatures.exportThemePreset(name);
+      exportThemePreset(name);
       println('theme exported.', 'ok');
     };
 
@@ -1343,14 +1344,14 @@
         println('usage: GDRIVECONFIG <client_id> <api_key>', 'error');
         return;
       }
-      TerminalListFeatures.setGDriveCredentials(clientId, apiKey);
+      setGDriveCredentials(clientId, apiKey);
       println('gdrive credentials stored for this session. Keep your keys secure.', 'ok');
     };
 
     cmd.backup = (args)=>{
       const provider = args[0] || 'local';
       const mode = args[1] || 'upload';
-      TerminalListFeatures.syncWithCloud(provider, mode)
+      syncWithCloud(provider, mode)
         .then(()=> println(mode === 'upload' ? 'backup uploaded.' : 'backup restored.', 'ok'))
         .catch(err => println('backup failed: ' + err, 'error'));
     };
@@ -1359,7 +1360,7 @@
     cmd.collab = (args)=>{
       const session = args[0];
       if (!session) return println('usage: COLLAB <session>', 'error');
-      collabSession = TerminalListFeatures.startCollaboration(session);
+      collabSession = startCollaboration(session);
       if (collabSession && collabSession.broadcast) collabSession.broadcast();
       println('collaboration started.', 'ok');
     };


### PR DESCRIPTION
## Summary
- refactor features.js to provide named ES module exports instead of a global object
- update index.html to import helper functions and use them directly
- document new module usage in README

## Testing
- `node --check features.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5eac151dc8331afc4f60b75cde4e7