### PR TITLE
Add helper to clear recurring reminders

### DIFF
--- a/features.js
+++ b/features.js
@@ -36,6 +36,14 @@ function scheduleRecurringReminder(taskId, pattern) {
   recurringTimers.set(taskId, timer);
 }
 
+function clearRecurringReminder(taskId) {
+  const timer = recurringTimers.get(taskId);
+  if (timer) {
+    clearInterval(timer);
+    recurringTimers.delete(taskId);
+  }
+}
+
 function snoozeReminder(taskId, until) {
   const task = (window.items || []).find(t => t.id === taskId);
   if (!task) return;
@@ -341,6 +349,7 @@ function startCollaboration(sessionId, secret, saltBytes) {
 // Named exports for feature helpers
 export {
   scheduleRecurringReminder,
+  clearRecurringReminder,
   snoozeReminder,
   parseAdvancedQuery,
   editNoteRich,
@@ -348,6 +357,7 @@ export {
   applyThemePreset,
   exportThemePreset,
   startCollaboration,
-  setGDriveCredentials
+  setGDriveCredentials,
+  recurringTimers
 };
 

--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
 
   <script type="module" src="features.js"></script>
   <script type="module">
-    import { scheduleRecurringReminder, snoozeReminder, parseAdvancedQuery, applyThemePreset, exportThemePreset, setGDriveCredentials, syncWithCloud, startCollaboration } from './features.js';
+    import { scheduleRecurringReminder, clearRecurringReminder, snoozeReminder, parseAdvancedQuery, applyThemePreset, exportThemePreset, setGDriveCredentials, syncWithCloud, startCollaboration, recurringTimers } from './features.js';
     /************
      * STORAGE
      ************/
@@ -866,6 +866,7 @@
     cmd.delete = (args)=>{
       const t = resolveTaskRef(args[0], lastTaskListCache);
       if (!t) return println('not found', 'error');
+      clearRecurringReminder(t.id);
       notes.forEach(n=>{ if (n.taskId === t.id) n.taskId = null; });
       if (dueTimers.has(t.id)){
         clearTimeout(dueTimers.get(t.id));
@@ -878,6 +879,7 @@
       const ref = args.shift();
       const t = resolveTaskRef(ref, lastTaskListCache);
       if (!t) return println('not found', 'error');
+      clearRecurringReminder(t.id);
       const text = args.join(' ').trim();
       if (!text) return println('usage: EDIT <id|#> <text>', 'error');
       t.text = text; saveItems(items);
@@ -1766,6 +1768,12 @@
       setStatus('Installed');
       deferredPrompt = null;
       installBtn.classList.remove('enabled');
+    });
+
+    window.addEventListener('beforeunload', () => {
+      for (const timer of recurringTimers.values()) {
+        clearInterval(timer);
+      }
     });
 
     /************


### PR DESCRIPTION
## Summary
- add `clearRecurringReminder` helper and export recurring timers
- ensure task delete and edit commands stop recurring reminders
- clear all recurring reminders on page exit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ebd3fea4833189e63d758b6beff3