### PR TITLE
Add item indexing for faster advanced queries

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
 
   <script type="module" src="features.js"></script>
   <script type="module">
-    import { scheduleRecurringReminder, clearRecurringReminder, snoozeReminder, parseAdvancedQuery, applyThemePreset, exportThemePreset, setGDriveCredentials, syncWithCloud, startCollaboration, recurringTimers } from './features.js';
+    import { scheduleRecurringReminder, clearRecurringReminder, snoozeReminder, parseAdvancedQuery, applyThemePreset, exportThemePreset, setGDriveCredentials, syncWithCloud, startCollaboration, recurringTimers, indexItems } from './features.js';
     /************
      * STORAGE
      ************/
@@ -341,6 +341,7 @@
 
     let state = loadState();
     let items = state.items;
+    indexItems(items);
     let needsNoteMigration = false;
     let notes = state.notes.map(n=>{
       if (!n.body && n.text) needsNoteMigration = true;
@@ -401,7 +402,7 @@
       items.forEach(scheduleTaskNotification);
     }
 
-    function saveItems(v){ state.items = v; saveState(state); }
+    function saveItems(v){ state.items = v; indexItems(v); saveState(state); }
     function saveNotes(v){
       notes = v;
       window.notes = v;


### PR DESCRIPTION
## Summary
- index items by tags, priority, and completion flags
- use precomputed indexes in `parseAdvancedQuery`
- keep index up to date on load and save

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ecae0e988331b37ab9b80a1f547c