### PR TITLE
Load Google Drive credentials from runtime config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/README.md
+++ b/README.md
@@ -37,13 +37,17 @@ Terminal-List/
 
 ## Build
 
-Generate the asset manifest and cache version before deployment:
+Generate the asset manifest, runtime config, and cache version before deployment:
 
 ```bash
+GDRIVE_CLIENT_ID=<your_client_id> \
+GDRIVE_API_KEY=<your_api_key> \
 node build-manifest.js
 ```
 
-This script hashes core assets, writes `asset-manifest.js`, and updates the cache version used by `sw.js`.
+`build-manifest.js` hashes core assets, writes `asset-manifest.js`, and creates a `config.json` file using the `GDRIVE_CLIENT_ID` and `GDRIVE_API_KEY` environment variables. The service worker uses the manifest's version for cache busting.
+
+`config.json` is ignored by Git; see `config.template.json` for the expected structure. The app fetches this file at runtime to supply Google Drive credentials to `setGDriveCredentials`.
 
 ## Installation / Running
 
@@ -181,7 +185,7 @@ await syncWithCloud('local', 'download'); // restore from sandbox
 ```
 
 ### Google Drive Backup
-Run inside the app:
+`clientId` and `apiKey` are read from `config.json` at startup. To supply them manually, run inside the app:
 ```
 GDRIVECONFIG <client_id> <api_key>
 ```

--- a/asset-manifest.js
+++ b/asset-manifest.js
@@ -1,5 +1,5 @@
 self.__ASSET_MANIFEST = {
-  "version": "eeffaee7",
+  "version": "2565e96d",
   "files": [
     "./",
     "./index.html",
@@ -7,6 +7,7 @@ self.__ASSET_MANIFEST = {
     "./sw.js",
     "./features.js",
     "./icons/icon-192.png",
-    "./icons/icon-512.png"
+    "./icons/icon-512.png",
+    "./config.json"
   ]
 };

--- a/build-manifest.js
+++ b/build-manifest.js
@@ -9,13 +9,21 @@ const files = [
   'sw.js',
   'features.js',
   'icons/icon-192.png',
-  'icons/icon-512.png'
+  'icons/icon-512.png',
+  'config.json'
 ];
 
 const root = __dirname;
 
 function createManifest() {
   const hash = crypto.createHash('sha256');
+
+  // Write config.json from environment variables
+  const config = {
+    clientId: process.env.GDRIVE_CLIENT_ID || '',
+    apiKey: process.env.GDRIVE_API_KEY || ''
+  };
+  fs.writeFileSync(path.join(root, 'config.json'), JSON.stringify(config, null, 2));
 
   for (const file of files) {
     const filePath = path.join(root, file);
@@ -32,6 +40,7 @@ function createManifest() {
   const content = `self.__ASSET_MANIFEST = ${JSON.stringify(manifest, null, 2)};\n`;
   fs.writeFileSync(path.join(root, 'asset-manifest.js'), content);
   console.log(`Generated asset-manifest.js with version ${version}`);
+  console.log('Wrote config.json');
 }
 
 createManifest();

--- a/config.template.json
+++ b/config.template.json
@@ -1,0 +1,4 @@
+{
+  "clientId": "YOUR_GOOGLE_DRIVE_CLIENT_ID",
+  "apiKey": "YOUR_GOOGLE_API_KEY"
+}

--- a/index.html
+++ b/index.html
@@ -252,6 +252,19 @@
   <script type="module" src="features.js"></script>
   <script type="module">
     import { scheduleRecurringReminder, clearRecurringReminder, snoozeReminder, parseAdvancedQuery, applyThemePreset, exportThemePreset, setGDriveCredentials, syncWithCloud, startCollaboration, recurringTimers, indexItems } from './features.js';
+
+    // Load Google Drive credentials from config.json at runtime
+    fetch('./config.json')
+      .then(r => r.json())
+      .then(cfg => {
+        if (cfg.clientId && cfg.apiKey) {
+          setGDriveCredentials(cfg.clientId, cfg.apiKey);
+        }
+      })
+      .catch(() => {
+        // Missing or invalid config: credentials can be set manually via GDRIVECONFIG
+      });
+
     /************
      * STORAGE
      ************/


### PR DESCRIPTION
## Summary
- Fetch Google Drive API credentials from a runtime `config.json` instead of hard-coding them
- Add `config.template.json` and ignore `config.json`
- Build script now generates `config.json` from `GDRIVE_CLIENT_ID` and `GDRIVE_API_KEY`
- Document environment variables and config generation in README

## Testing
- `GDRIVE_CLIENT_ID=dummy GDRIVE_API_KEY=dummy node build-manifest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5f2709dbc833199d368d0d8a42629