### PR TITLE
Add GENPASS command for random 64-char passcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Type commands into the input bar or directly in the terminal view.
 - `import` — paste JSON to replace all data
 - `importshare` — paste shared item JSON and decrypt with a passcode
 - `wipe` — clear all data (with confirm)
+- `genpass` — generate a random 64-character passcode
 - `setpass` — set or clear passcode
 - `nopass` — allow saving without a passcode
 - `lock` — clear decrypted data from memory

--- a/app.js
+++ b/app.js
@@ -568,6 +568,7 @@ cmd.help = () => {
   println('  - import — paste JSON to replace all data');
   println('  - importshare — paste shared item JSON and decrypt with a passcode');
   println('  - wipe — clear all data (with confirm)');
+  println('  - genpass — generate a random 64-character passcode');
   println('  - setpass — set or clear passcode');
   println('  - nopass — allow saving without a passcode');
   println('  - lock — clear decrypted data from memory');
@@ -1231,8 +1232,15 @@ cmd.importshare = async ()=>{
   }catch(e){
     println('import failed: ' + e.message, 'error');
   }
-};
+}; 
 cmd.wipe = ()=> openModal();
+
+cmd.genpass = ()=>{
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  const pass = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+  println(pass);
+};
 
 cmd.setpass = async ()=>{
   if (locked){ println('unlock first', 'error'); return; }


### PR DESCRIPTION
## Summary
- Add `GENPASS` command to generate a 64-character hexadecimal passcode
- Document the new command in help output and README

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e32104748331a0ea32eeeba80fce