### PR TITLE
Improve genpass to use full character set

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Type commands into the input bar or directly in the terminal view.
 - `import` — paste JSON to replace all data
 - `importshare` — paste shared item JSON and decrypt with a passcode
 - `wipe` — clear all data (with confirm)
-- `genpass` — generate a random 64-character passcode
+- `genpass` — generate a random 64-character passcode using mixed-case letters, digits, and special symbols
 - `setpass` — set or clear passcode
 - `nopass` — allow saving without a passcode
 - `lock` — clear decrypted data from memory

--- a/app.js
+++ b/app.js
@@ -568,7 +568,7 @@ cmd.help = () => {
   println('  - import — paste JSON to replace all data');
   println('  - importshare — paste shared item JSON and decrypt with a passcode');
   println('  - wipe — clear all data (with confirm)');
-  println('  - genpass — generate a random 64-character passcode');
+  println('  - genpass — generate a random 64-character passcode using letters, digits, and symbols');
   println('  - setpass — set or clear passcode');
   println('  - nopass — allow saving without a passcode');
   println('  - lock — clear decrypted data from memory');
@@ -1236,9 +1236,10 @@ cmd.importshare = async ()=>{
 cmd.wipe = ()=> openModal();
 
 cmd.genpass = ()=>{
-  const bytes = new Uint8Array(32);
-  crypto.getRandomValues(bytes);
-  const pass = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+  const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-=[]{}|;:,.<>/?';
+  const values = new Uint8Array(64);
+  crypto.getRandomValues(values);
+  const pass = Array.from(values, v => charset[v % charset.length]).join('');
   println(pass);
 };
 


### PR DESCRIPTION
## Summary
- replace hex-based generator with full letter/digit/symbol charset
- document new behavior for `genpass` command

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8e8ede2a08331b7b9d34e08009e38