### PR TITLE
Require passcode before saving data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Terminal List
 
 **Terminal List** is a browser-based Progressive Web App (PWA) for managing tasks, notes and messages in a terminal-style interface.
-It supports optional passcode protection with AES-256 encryption, JSON export/import, due-date notifications, customizable themes, and an emergency data wipe function.
+It requires a passcode before storing any data and encrypts everything with AES-256-GCM. The app also supports JSON export/import, due-date notifications, customizable themes, and an emergency data wipe function.
 
 ## Features
 
 - ✅ **Tasks**: Add items, tag them, set priorities or due dates, and search.
 - 📝 **Notes**: Create standalone notes or link them to tasks, and tag them.
-- 🔐 **Passcode Lock**: Protect your data with AES-256-GCM encryption (derived with PBKDF2). Saving is blocked until you set a passcode or explicitly opt out with `nopass`.
+- 🔐 **Passcode Lock**: Protect your data with AES-256-GCM encryption (derived with PBKDF2). Saving is blocked until you set a passcode.
 - ⏰ **Due-date Notifications**: Receive reminders for tasks on their due date (requires notification permission).
 - 🎨 **Custom Themes**: Adjust terminal colors with the `THEME` command.
 - 📤 **Export/Import**: Backup or restore tasks, notes, and messages in JSON format.
@@ -134,8 +134,7 @@ Type commands into the input bar or directly in the terminal view.
 - `importshare` — paste shared item JSON and decrypt with a passcode
 - `wipe` — clear all data (with confirm)
 - `genpass [-w <n>] [-s <sep>]` — generate a Diceware passphrase (default: 8 words, space-separated)
-- `setpass` — set or clear passcode
-- `nopass` — allow saving without a passcode
+- `setpass` — set passcode
 - `lock` — clear decrypted data from memory
 - `unlock` — restore data with passcode
 
@@ -221,8 +220,8 @@ await collab.broadcast(); // sync current tasks/notes to other tabs with same se
 
 ## Security Notes
 
-- On startup, the app blocks saving until you run `setpass` or explicitly decline with `nopass`.
-- If `nopass` is used, data is saved in browser localStorage unencrypted.
+- On startup, the app blocks saving until you set a passcode with `setpass`.
+- Without a passcode, data cannot be stored in browser localStorage.
 - If a passcode is set, all data is encrypted at rest using AES-256-GCM.
 - Passcode derivation uses PBKDF2 with 200k iterations.
 - Remember your passcode! Without it, encrypted data cannot be recovered.


### PR DESCRIPTION
## Summary
- remove option to skip passcode and simplify state saving
- require a passcode before any data can be stored
- document mandatory passcode in README

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8f68564d48331b88d489de80fe760