### PR TITLE
refactor: avoid window state

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-import { scheduleRecurringReminder, clearRecurringReminder, snoozeReminder, parseAdvancedQuery, applyThemePreset, exportThemePreset, setGDriveCredentials, syncWithCloud, recurringTimers, indexItems } from './features.js';
+import { scheduleRecurringReminder, clearRecurringReminder, snoozeReminder, parseAdvancedQuery, applyThemePreset, exportThemePreset, setGDriveCredentials, syncWithCloud, recurringTimers, indexItems, registerDataGetters } from './features.js';
 let encryptionModule;
 function loadEncryption() {
   if (!encryptionModule) encryptionModule = import("./encryption.js");
@@ -124,12 +124,14 @@ let notes = state.notes.map(n=>{
   };
 });
 state.notes = notes;
-// expose notes array for feature helpers
-window.notes = notes;
 if (needsNoteMigration) saveNotes(notes);
 let messages = state.messages || [];
 state.messages = messages;
-window.messages = messages;
+registerDataGetters({
+  items: () => items,
+  notes: () => notes,
+  messages: () => messages
+});
 
 // Service Worker registration and notification timers
 let swRegistration = null;
@@ -194,13 +196,11 @@ if (navigator.serviceWorker) {
 function saveItems(v){ state.items = v; indexItems(v); saveState(state).catch(()=>{}); }
 function saveNotes(v){
   notes = v;
-  window.notes = v;
   state.notes = v;
   saveState(state).catch(()=>{});
 }
 function saveMessages(v){
   messages = v;
-  window.messages = v;
   state.messages = v;
   saveState(state).catch(()=>{});
 }

--- a/collaboration.js
+++ b/collaboration.js
@@ -1,3 +1,5 @@
+import { getItems, getNotes, getMessages } from './features.js';
+
 function startCollaboration(sessionId, secret, saltBytes) {
   const channel = new BroadcastChannel(`tl-collab-${sessionId}`);
   const encoder = new TextEncoder();
@@ -55,12 +57,9 @@ function startCollaboration(sessionId, secret, saltBytes) {
       );
       const data = JSON.parse(decoder.decode(decrypted));
       if (data && data.items && data.notes) {
-        window.items = data.items;
-        window.notes = data.notes;
-        window.messages = data.messages || [];
-        if (typeof saveItems === 'function') saveItems(window.items);
-        if (typeof saveNotes === 'function') saveNotes(window.notes);
-        if (typeof saveMessages === 'function') saveMessages(window.messages);
+        if (typeof saveItems === 'function') saveItems(data.items);
+        if (typeof saveNotes === 'function') saveNotes(data.notes);
+        if (typeof saveMessages === 'function') saveMessages(data.messages || []);
         if (typeof rescheduleAllNotifications === 'function') rescheduleAllNotifications();
       }
     } catch (err) {
@@ -71,7 +70,7 @@ function startCollaboration(sessionId, secret, saltBytes) {
   async function broadcast() {
     const key = await getKey();
     const iv = crypto.getRandomValues(new Uint8Array(12));
-    const payload = { items: window.items || [], notes: window.notes || [], messages: window.messages || [] };
+    const payload = { items: getItems(), notes: getNotes(), messages: getMessages() };
     const encrypted = await crypto.subtle.encrypt(
       { name: 'AES-GCM', iv },
       key,


### PR DESCRIPTION
## Summary
- remove assignments to `window.notes` and `window.messages`
- provide registered getters in `features.js` for items, notes, and messages
- update collaboration and sync helpers to use these getters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b900b6d1588331b4fb914f1965e461