### PR TITLE
Clear command history when locking

### DIFF
--- a/app.js
+++ b/app.js
@@ -1332,6 +1332,9 @@ cmd.lock = ()=>{
   passKey = null;
   locked = true;
   lastTaskListCache = null; lastNoteListCache = null;
+  localStorage.removeItem(HISTORY_KEY);
+  history = [];
+  historyIndex = 0;
   println('locked.', 'ok');
   setTimeout(() => location.reload(), 0);
 };


### PR DESCRIPTION
## Summary
- Clear command history on lock by removing the stored history and resetting state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b901e96aa083318192139cb14d319f