### PR TITLE
feat: switch to scrypt key derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It requires a passcode before storing any data and encrypts everything with AES-
 
 - ✅ **Tasks**: Add items, tag them, set priorities or due dates, and search.
 - 📝 **Notes**: Create standalone notes or link them to tasks, and tag them.
-- 🔐 **Passcode Lock**: Protect your data with AES-256-GCM encryption (derived with PBKDF2). Saving is blocked until you set a passcode.
+- 🔐 **Passcode Lock**: Protect your data with AES-256-GCM encryption (keys derived with scrypt). Saving is blocked until you set a passcode.
 - ⏰ **Due-date Notifications**: Receive reminders for tasks on their due date (requires notification permission).
 - 🎨 **Custom Themes**: Adjust terminal colors with the `THEME` command.
 - 📤 **Export/Import**: Backup or restore tasks, notes, and messages in JSON format.
@@ -223,8 +223,8 @@ await collab.broadcast(); // sync current tasks/notes to other tabs with same se
 - On startup, the app blocks saving until you set a passcode with `setpass`.
 - Without a passcode, data cannot be stored in browser localStorage.
 - If a passcode is set, all data is encrypted at rest using AES-256-GCM.
- - Passcode derivation uses PBKDF2 with 600k iterations (configurable and stored
-   with your data so the cost can be increased in future versions).
+ - Passcode derivation uses scrypt with configurable parameters (stored with
+   your data so the cost can be increased in future versions).
 - Remember your passcode! Without it, encrypted data cannot be recovered.
 - Google Drive credentials configured via `GDRIVECONFIG` live only in memory; never commit API keys or share them publicly.
 - When updating the Google API script, recompute its Subresource Integrity hash using:

--- a/asset-manifest.js
+++ b/asset-manifest.js
@@ -1,5 +1,5 @@
 self.__ASSET_MANIFEST = {
-  "version": "e0babead",
+  "version": "27581c98",
   "files": [
     "./",
     "./index.html",
@@ -8,6 +8,7 @@ self.__ASSET_MANIFEST = {
     "./features.js",
     "./app.js",
     "./encryption.js",
+    "./scrypt.js",
     "./collaboration.js",
     "./icons/icon-192.png",
     "./icons/icon-512.png",

--- a/build-manifest.js
+++ b/build-manifest.js
@@ -3,15 +3,19 @@ const path = require('path');
 const crypto = require('crypto');
 
 // Files to include in the asset manifest
-const files = [
-  'index.html',
-  'manifest.webmanifest',
-  'sw.js',
-  'features.js',
-  'icons/icon-192.png',
-  'icons/icon-512.png',
-  'config.json'
-];
+  const files = [
+    'index.html',
+    'manifest.webmanifest',
+    'sw.js',
+    'features.js',
+    'app.js',
+    'encryption.js',
+    'scrypt.js',
+    'collaboration.js',
+    'icons/icon-192.png',
+    'icons/icon-512.png',
+    'config.json'
+  ];
 
 const root = __dirname;
 

--- a/encryption.js
+++ b/encryption.js
@@ -4,45 +4,42 @@ const dec = new TextDecoder();
 function b64(buf){ return btoa(String.fromCharCode(...new Uint8Array(buf))); }
 function b64ToBuf(str){ return Uint8Array.from(atob(str), c=>c.charCodeAt(0)); }
 
-// Default iteration count for PBKDF2. Expose this so future versions can
-// increase the work factor without requiring data migration.
-const DEFAULT_PBKDF2_ITERATIONS = 600_000;
-// Derive an AES-GCM key from a passphrase using PBKDF2.  The iteration count
-// is configurable and defaults to a high number to make brute-force attempts
-// more expensive.
-async function deriveKey(pass, saltBytes, iterations = DEFAULT_PBKDF2_ITERATIONS){
-  const baseKey = await crypto.subtle.importKey('raw', enc.encode(pass), 'PBKDF2', false, ['deriveKey']);
-  return crypto.subtle.deriveKey(
-    { name:'PBKDF2', salt: saltBytes, iterations, hash:'SHA-256' },
-    baseKey,
-    { name:'AES-GCM', length:256 },
-    false,
-    ['encrypt','decrypt']
-  );
+// Default scrypt parameters. Exposed so future versions can tune the work
+// factor without requiring data migration.
+const DEFAULT_SCRYPT_PARAMS = { N: 2 ** 15, r: 8, p: 1 };
+// Derive an AES-GCM key from a passphrase using scrypt. The parameters are
+// stored alongside the encrypted payload so the cost can be adjusted over time.
+async function deriveKey(pass, saltBytes, params = DEFAULT_SCRYPT_PARAMS){
+  const { scrypt } = await import('./scrypt.js');
+  const passBytes = enc.encode(pass);
+  const dk = await scrypt(passBytes, saltBytes, { ...params, dkLen: 32 });
+  return crypto.subtle.importKey('raw', dk, { name:'AES-GCM' }, false, ['encrypt','decrypt']);
 }
 
 // Encrypt an object for sharing using the supplied passphrase.  The returned
 // payload includes the parameters necessary to re-derive the key in the
 // future, allowing the cost factor to be tuned without breaking old data.
-async function encryptForShare(obj, pass, iterations = DEFAULT_PBKDF2_ITERATIONS){
+async function encryptForShare(obj, pass, params = DEFAULT_SCRYPT_PARAMS){
   const saltBytes = crypto.getRandomValues(new Uint8Array(16));
   const iv = crypto.getRandomValues(new Uint8Array(12));
-  const key = await deriveKey(pass, saltBytes, iterations);
+  const key = await deriveKey(pass, saltBytes, params);
   const data = enc.encode(JSON.stringify(obj));
   const buf = await crypto.subtle.encrypt({ name:'AES-GCM', iv }, key, data);
-  return { salt: b64(saltBytes), iv: b64(iv), data: b64(buf), iterations };
+  return { salt: b64(saltBytes), iv: b64(iv), data: b64(buf), kdf: { name:'scrypt', ...params } };
 }
 
-// Decrypt a payload created by encryptForShare.  If the payload specifies an
-// iteration count use it, otherwise fall back to the current default.
+// Decrypt a payload created by encryptForShare.  If the payload specifies
+// scrypt parameters use them, otherwise fall back to the current defaults.
 async function decryptShared(encObj, pass){
   const saltBytes = b64ToBuf(encObj.salt);
   const iv = b64ToBuf(encObj.iv);
   const data = b64ToBuf(encObj.data);
-  const iterations = encObj.iterations || DEFAULT_PBKDF2_ITERATIONS;
-  const key = await deriveKey(pass, saltBytes, iterations);
+  const params = (encObj.kdf && encObj.kdf.name === 'scrypt')
+    ? { N: encObj.kdf.N, r: encObj.kdf.r, p: encObj.kdf.p }
+    : DEFAULT_SCRYPT_PARAMS;
+  const key = await deriveKey(pass, saltBytes, params);
   const buf = await crypto.subtle.decrypt({ name:'AES-GCM', iv }, key, data);
   return JSON.parse(dec.decode(new Uint8Array(buf)));
 }
 
-export { deriveKey, encryptForShare, decryptShared, DEFAULT_PBKDF2_ITERATIONS };
+export { deriveKey, encryptForShare, decryptShared, DEFAULT_SCRYPT_PARAMS };

--- a/scrypt.js
+++ b/scrypt.js
@@ -1,0 +1,77 @@
+// Minimal scrypt implementation adapted from scrypt-js (MIT License)
+// https://github.com/ricmoo/scrypt-js
+// This module exposes a single async function `scrypt` that derives a key of
+// length `dkLen` bytes from `password` and `salt` using the provided
+// parameters N, r, and p.
+
+export async function scrypt(password, salt, { N, r, p, dkLen }) {
+  if (!(password instanceof Uint8Array)) password = new Uint8Array(password);
+  if (!(salt instanceof Uint8Array)) salt = new Uint8Array(salt);
+  if (!Number.isInteger(N) || N <= 1 || (N & (N - 1)) !== 0) throw new Error('N must be power of two');
+  if (r <= 0 || p <= 0) throw new Error('Invalid r or p');
+  const blockSize = 128 * r;
+  const PBKDF2 = async (pwd, slt, len) => {
+    const key = await crypto.subtle.importKey('raw', pwd, 'PBKDF2', false, ['deriveBits']);
+    const bits = await crypto.subtle.deriveBits({ name: 'PBKDF2', salt: slt, iterations: 1, hash: 'SHA-256' }, key, len * 8);
+    return new Uint8Array(bits);
+  };
+  let B = await PBKDF2(password, salt, p * blockSize);
+  const V = new Uint32Array(N * (32 * r));
+  const XY = new Uint32Array(64 * r);
+  const blockMix = (B32) => {
+    let X = B32.slice((2 * r - 1) * 16, 2 * r * 16);
+    const Y = new Uint32Array(32 * r);
+    for (let i = 0; i < 2 * r; i++) {
+      for (let j = 0; j < 16; j++) X[j] ^= B32[i * 16 + j];
+      salsa20_8(X);
+      for (let j = 0; j < 16; j++) Y[i * 16 + j] = X[j];
+    }
+    for (let i = 0; i < r; i++) {
+      for (let j = 0; j < 16; j++) B32[i * 16 + j] = Y[2 * i * 16 + j];
+      for (let j = 0; j < 16; j++) B32[(i + r) * 16 + j] = Y[(2 * i + 1) * 16 + j];
+    }
+  };
+  const ROMix = (Bslice) => {
+    XY.set(Bslice);
+    for (let i = 0; i < N; i++) {
+      V.set(XY, i * XY.length);
+      blockMix(XY);
+    }
+    for (let i = 0; i < N; i++) {
+      const j = XY[(2 * r - 1) * 16] & (N - 1);
+      for (let k = 0; k < XY.length; k++) XY[k] ^= V[j * XY.length + k];
+      blockMix(XY);
+    }
+    Bslice.set(XY);
+  };
+  for (let i = 0; i < p; i++) {
+    const Bi = B.subarray(i * blockSize, (i + 1) * blockSize);
+    ROMix(new Uint32Array(Bi.buffer, Bi.byteOffset, Bi.byteLength / 4));
+  }
+  B = await PBKDF2(password, B, dkLen);
+  return B;
+}
+
+function R(a, b) { return (a << b) | (a >>> (32 - b)); }
+function salsa20_8(B) {
+  let x = B.slice();
+  for (let i = 0; i < 8; i += 2) {
+    x[4] ^= R(x[0] + x[12], 7); x[8] ^= R(x[4] + x[0], 9);
+    x[12] ^= R(x[8] + x[4], 13); x[0] ^= R(x[12] + x[8], 18);
+    x[9] ^= R(x[5] + x[1], 7); x[13] ^= R(x[9] + x[5], 9);
+    x[1] ^= R(x[13] + x[9], 13); x[5] ^= R(x[1] + x[13], 18);
+    x[14] ^= R(x[10] + x[6], 7); x[2] ^= R(x[14] + x[10], 9);
+    x[6] ^= R(x[2] + x[14], 13); x[10] ^= R(x[6] + x[2], 18);
+    x[3] ^= R(x[15] + x[11], 7); x[7] ^= R(x[3] + x[15], 9);
+    x[11] ^= R(x[7] + x[3], 13); x[15] ^= R(x[11] + x[7], 18);
+    x[1] ^= R(x[0] + x[3], 7); x[2] ^= R(x[1] + x[0], 9);
+    x[3] ^= R(x[2] + x[1], 13); x[0] ^= R(x[3] + x[2], 18);
+    x[6] ^= R(x[5] + x[4], 7); x[7] ^= R(x[6] + x[5], 9);
+    x[4] ^= R(x[7] + x[6], 13); x[5] ^= R(x[4] + x[7], 18);
+    x[11] ^= R(x[10] + x[9], 7); x[8] ^= R(x[11] + x[10], 9);
+    x[9] ^= R(x[8] + x[11], 13); x[10] ^= R(x[9] + x[8], 18);
+    x[12] ^= R(x[15] + x[14], 7); x[13] ^= R(x[12] + x[15], 9);
+    x[14] ^= R(x[13] + x[12], 13); x[15] ^= R(x[14] + x[13], 18);
+  }
+  for (let i = 0; i < 16; i++) B[i] = (B[i] + x[i]) >>> 0;
+}


### PR DESCRIPTION
## Summary
- replace PBKDF2-based key derivation with scrypt and store its parameters alongside encrypted payloads
- derive passcode keys using scrypt and persist tuning parameters with local state
- add local scrypt implementation and update manifests/documentation accordingly

## Testing
- `GDRIVE_CLIENT_ID=placeholder GDRIVE_API_KEY=placeholder node build-manifest.js`
- `node -e "import('./encryption.js').then(m=>console.log('loaded')).catch(e=>console.error(e));"`
- `node -e "import('./scrypt.js').then(()=>console.log('scrypt ok')).catch(e=>console.error(e));"`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b902643ca08331911550adfb75c722