### PR TITLE
Add basic password manager commands

### DIFF
--- a/features.js
+++ b/features.js
@@ -7,10 +7,12 @@
 let getItems = () => [];
 let getNotes = () => [];
 let getMessages = () => [];
-function registerDataGetters({ items, notes, messages }) {
+let getPasswords = () => [];
+function registerDataGetters({ items, notes, messages, passwords }) {
   if (items) getItems = items;
   if (notes) getNotes = notes;
   if (messages) getMessages = messages;
+  if (passwords) getPasswords = passwords;
 }
 
 // --- Recurring & Snoozeable Reminders ------------------------------------
@@ -264,7 +266,7 @@ function syncWithCloud(provider = 'local', mode = 'upload') {
 
   const key = `terminal-list-sync-${provider}`;
   if (mode === 'upload') {
-    const data = JSON.stringify({ items: getItems(), notes: getNotes(), messages: getMessages() });
+    const data = JSON.stringify({ items: getItems(), notes: getNotes(), messages: getMessages(), passwords: getPasswords() });
     localStorage.setItem(key, data);
     return Promise.resolve('uploaded');
   } else {
@@ -274,6 +276,7 @@ function syncWithCloud(provider = 'local', mode = 'upload') {
     if (typeof saveItems === 'function') saveItems(data.items || []);
     if (typeof saveNotes === 'function') saveNotes(data.notes || []);
     if (typeof saveMessages === 'function') saveMessages(data.messages || []);
+    if (typeof savePasswords === 'function') savePasswords(data.passwords || []);
     if (typeof rescheduleAllNotifications === 'function') rescheduleAllNotifications();
     return Promise.resolve('downloaded');
   }
@@ -322,6 +325,7 @@ export {
   registerDataGetters,
   getItems,
   getNotes,
-  getMessages
+  getMessages,
+  getPasswords
 };
 

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         <button class="terminal" id="note-cancel">Cancel</button>
         <button class="terminal" id="note-save">Save</button>
       </div>
-    </div>
+  </div>
   </div>
 
   <div id="msg-modal" role="dialog" aria-modal="true" aria-labelledby="msg-modal-title">
@@ -86,6 +86,26 @@
       <div class="row">
         <button class="terminal" id="msg-cancel">Cancel</button>
         <button class="terminal" id="msg-share">Share</button>
+      </div>
+  </div>
+  </div>
+
+  <div id="pass-modal" role="dialog" aria-modal="true" aria-labelledby="pass-modal-title">
+    <div class="card">
+      <div id="pass-modal-title" class="line">Add Password</div>
+      <label for="pass-title" class="line">Title</label>
+      <input id="pass-title" type="text" />
+      <label for="pass-username" class="line">Username</label>
+      <input id="pass-username" type="text" />
+      <label for="pass-password" class="line">Password</label>
+      <input id="pass-password" type="password" />
+      <label for="pass-website" class="line">Website</label>
+      <input id="pass-website" type="text" />
+      <label for="pass-notes" class="line">Notes</label>
+      <textarea id="pass-notes" rows="3"></textarea>
+      <div class="row">
+        <button class="terminal" id="pass-cancel">Cancel</button>
+        <button class="terminal" id="pass-save">Save</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Add PASSNEW/PASSEDIT/PASSDEL/PASSVIEW commands for managing password sets
- Store password entries in encrypted state and include in export/import and cloud sync
- Introduce password modal UI and update stats and help text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f2e2376c8331b2e7cddf86cdd793