### PR TITLE
Include password modal in global modal styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -76,7 +76,7 @@
     .ok{ color: #7fffd4; }
     .task-done{ opacity: 0.7; text-decoration: line-through; }
     /* Modal + Install Help */
-    #modal, #install-help, #note-modal, #pic-modal, #msg-modal{
+    #modal, #install-help, #note-modal, #pic-modal, #msg-modal, #pass-modal{
       position: fixed; inset: 0; display: none;
       align-items: center; justify-content: center;
       background: rgba(0,0,0,0.92);


### PR DESCRIPTION
## Summary
- Hide and style the password dialog by adding `#pass-modal` to the shared modal selector
- `showPassModal` and `hidePassModal` manage visibility through JavaScript

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b90c06c9208331a312d1ecf822974c