### PR TITLE
Fix command input blocking when DOMPurify not loaded

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <!-- PWA refs -->
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#32cd32">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; script-src 'self' https://apis.google.com; style-src 'self';"/>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; script-src 'self' https://apis.google.com https://cdnjs.cloudflare.com; style-src 'self';"/>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous"></script>
   <script src="sanitize.js"></script>
   <link rel="stylesheet" href="styles.css">

--- a/sanitize.js
+++ b/sanitize.js
@@ -1,11 +1,26 @@
 (function (global) {
-  // DOMPurify is loaded separately from a vetted CDN bundle
+  // DOMPurify is loaded separately from a vetted CDN bundle when available
   const ALLOWED_TAGS = ['b', 'i', 'em', 'strong', 'a', 'p', 'br', 'ul', 'ol', 'li'];
   const ALLOWED_ATTR = { a: ['href', 'target', 'rel'] };
 
+  function basicEscape(str) {
+    return str.replace(/[&<>"']/g, c => ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    }[c]));
+  }
+
   function sanitizeHTML(input) {
     if (input == null) return '';
-    return global.DOMPurify.sanitize(input, { ALLOWED_TAGS, ALLOWED_ATTR });
+    const str = String(input);
+    if (global.DOMPurify && typeof global.DOMPurify.sanitize === 'function') {
+      return global.DOMPurify.sanitize(str, { ALLOWED_TAGS, ALLOWED_ATTR });
+    }
+    // Fallback to basic escaping if DOMPurify failed to load
+    return basicEscape(str);
   }
 
   global.sanitizeHTML = sanitizeHTML;


### PR DESCRIPTION
## Summary
- Allow DOMPurify CDN through Content Security Policy
- Fallback to basic escaping when DOMPurify fails to load

## Testing
- `node --check sanitize.js && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68b90b0a75008331bf243385d1605a87