### PR TITLE
Add noopener noreferrer to attachment links

### DIFF
--- a/app.js
+++ b/app.js
@@ -475,6 +475,7 @@ function printNote(n, indexShown){
         a.href = att;
         a.textContent = att;
         a.target = '_blank';
+        a.rel = 'noopener noreferrer';
         a.style.marginRight = '6px';
         adiv.appendChild(a);
       }
@@ -994,6 +995,7 @@ cmd.readnote = (args)=>{
         a.href = att;
         a.textContent = att;
         a.target = '_blank';
+        a.rel = 'noopener noreferrer';
         a.style.marginRight = '6px';
         adiv.appendChild(a);
       }


### PR DESCRIPTION
## Summary
- ensure note attachment links opened in new tabs include `rel="noopener noreferrer"`
- verified no other `_blank` targets lacked `rel`

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68b91eb6785c833181db752d2e13a89c