### PR TITLE
Restrict image attachments to safe formats

### DIFF
--- a/app.js
+++ b/app.js
@@ -255,8 +255,14 @@ async function loadImageBlob(id){
     req.onerror = ()=>resolve(null);
   });
 }
+// Only allow a small set of safe image types. If additional formats are enabled
+// in the future, strip metadata or sanitize images server-side to avoid XSS or
+// tracking vectors.
+const ALLOWED_IMAGE_TYPES = ['image/png','image/jpeg','image/gif'];
 function isImageAttachment(a){
-  return a && (a.startsWith('data:image') || a.startsWith('idb:'));
+  if (!a) return false;
+  if (a.startsWith('idb:')) return true;
+  return ALLOWED_IMAGE_TYPES.some(t=>a.startsWith(`data:${t}`));
 }
 async function resolveAttachmentUrl(a){
   if (a.startsWith('idb:')){
@@ -372,7 +378,7 @@ function showAttachmentError(msg){
 }
 function handleAttachmentFiles(fileList){
   Array.from(fileList).forEach(file=>{
-    if (!file.type.startsWith('image/')){
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)){
       showAttachmentError('Unsupported file type');
       return;
     }


### PR DESCRIPTION
## Summary
- allow only PNG, JPEG, and GIF attachments
- flag unsupported attachment types
- note future need for server-side sanitization before expanding formats

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b92079b7088331a31325f02683398c