### PR TITLE
chore: add package metadata and audit workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci --ignore-scripts
+      - run: npm audit --audit-level=high

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "terminal-list",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "terminal-list",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "terminal-list",
+  "version": "1.0.0",
+  "description": "Browser-based PWA for managing tasks, notes, and messages in a terminal-style interface",
+  "private": true,
+  "scripts": {
+    "build": "node build-manifest.js",
+    "prepublishOnly": "npm audit"
+  }
+}


### PR DESCRIPTION
## Summary
- add npm package metadata and lock file
- check for vulnerabilities during CI and prepublish

## Testing
- `npm audit --audit-level=high`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b92b5dc8c48331bb123df118b6ebf6