### PR TITLE
Add no-store Cache-Control for config and document headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,27 @@ Then visit: [http://localhost:8080](http://localhost:8080)
 Your browser will prompt you to install the PWA for a native-like experience.
 
 ### 3. Hosting
-You can host the files on GitHub Pages, Netlify, Vercel, or any static web server.  
+You can host the files on GitHub Pages, Netlify, Vercel, or any static web server.
 Once hosted over HTTPS, you can install Terminal List on multiple devices.
+
+#### Production Server Headers
+The service worker treats some endpoints (like `config.json`) as sensitive and
+adds `Cache-Control: no-store` to their responses. Configure your production
+server to send the same header so these files are never cached. For example,
+with **nginx**:
+
+```
+location /config.json {
+  add_header Cache-Control "no-store";
+}
+```
+
+Verify the header with:
+
+```
+curl -I https://your-domain/config.json
+# Expect: Cache-Control: no-store
+```
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "node build-manifest.js",
-    "prepublishOnly": "npm audit"
+    "prepublishOnly": "npm audit",
+    "test": "node test/cache-header.test.js"
   }
 }

--- a/sw.js
+++ b/sw.js
@@ -3,6 +3,7 @@ importScripts('./asset-manifest.js');
 
 const CACHE_NAME = `terminal-list-${self.__ASSET_MANIFEST.version}`;
 const ASSETS = self.__ASSET_MANIFEST.files;
+const NO_STORE_PATHS = ['/config.json'];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -27,6 +28,22 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const req = event.request;
   if (req.method !== 'GET') return;
+
+  const url = new URL(req.url);
+  if (NO_STORE_PATHS.includes(url.pathname)) {
+    event.respondWith(
+      fetch(req).then((netRes) => {
+        const headers = new Headers(netRes.headers);
+        headers.set('Cache-Control', 'no-store');
+        return new Response(netRes.body, {
+          status: netRes.status,
+          statusText: netRes.statusText,
+          headers,
+        });
+      })
+    );
+    return;
+  }
 
   event.respondWith(
     (async () => {

--- a/test/cache-header.test.js
+++ b/test/cache-header.test.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const content = fs.readFileSync('sw.js', 'utf8');
+if (content.includes('Cache-Control') && content.includes('no-store')) {
+  console.log('Cache-Control no-store header found in service worker.');
+} else {
+  console.error('Cache-Control no-store header missing in service worker.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- prevent caching of sensitive `config.json` by marking requests with `Cache-Control: no-store` in the service worker
- describe required production server headers and a curl check to verify them
- add a simple test to ensure the service worker includes the no-store header logic

## Testing
- `npm test`
- `curl -I http://localhost:9100/config.json`

------
https://chatgpt.com/codex/tasks/task_e_68b9331b5b0483319b7956dd1e136706