### PR TITLE
Add PASSLIST command to list stored password sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ Type commands into the input bar or directly in the terminal view.
 - `replymsg <id|#>` — reply to a message
 - `delmsg <id|#>` — delete a message
 
+### Passwords
+- `passlist` — list password sets
+- `passnew` — add a password set
+- `passedit <id|#>` — edit a password set
+- `passdel <id|#>` — delete a password set
+- `passview <id|#>` — show a password set
+
 ### Security & Data
 - `stats` — summary counts
 - `clear` — clear the display


### PR DESCRIPTION
## Summary
- add PASSLIST to display stored password sets
- support resolving password references by id or list index
- document password commands in help and README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b93766e2c48331a8e7c80d766bd4b9