### PR TITLE
Strip EXIF metadata from uploaded images

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 import { scheduleRecurringReminder, clearRecurringReminder, snoozeReminder, parseAdvancedQuery, applyThemePreset, exportThemePreset, setGDriveCredentials, syncWithCloud, recurringTimers, indexItems, registerDataGetters } from './features.js';
+import stripImageMetadata from './third_party/strip-metadata.js';
 let encryptionModule;
 function loadEncryption() {
   if (!encryptionModule) encryptionModule = import("./encryption.js");
@@ -1758,7 +1759,13 @@ noteSave.addEventListener('click', async ()=>{
     attachments = existing.concat(attachments);
   }
   for (const entry of pendingAttachmentFiles){
-    let ref = await storeImageBlob(entry.file);
+    let processed = entry.file;
+    try {
+      processed = await stripImageMetadata(entry.file);
+    } catch (e) {
+      console.warn('Failed to strip metadata', e);
+    }
+    let ref = await storeImageBlob(processed);
     if (ref) attachments.push('idb:'+ref);
     else if (entry.dataUrl) attachments.push(entry.dataUrl);
   }

--- a/asset-manifest.js
+++ b/asset-manifest.js
@@ -1,5 +1,5 @@
 self.__ASSET_MANIFEST = {
-  "version": "bdde3b68",
+  "version": "cc1ae25a",
   "files": [
     "./",
     "./index.html",
@@ -11,6 +11,7 @@ self.__ASSET_MANIFEST = {
     "./scrypt.js",
     "./collaboration.js",
     "./third_party/purify.min.js",
+    "./third_party/strip-metadata.js",
     "./icons/icon-192.png",
     "./icons/icon-512.png",
     "./config.json"

--- a/build-manifest.js
+++ b/build-manifest.js
@@ -13,6 +13,7 @@ const crypto = require('crypto');
     'scrypt.js',
     'collaboration.js',
     'third_party/purify.min.js',
+    'third_party/strip-metadata.js',
     'icons/icon-192.png',
     'icons/icon-512.png',
     'config.json'

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "build": "node build-manifest.js",
     "prepublishOnly": "npm audit",
-    "test": "node test/cache-header.test.js"
+    "test": "node test/cache-header.test.js && node test/strip-metadata.test.js"
   }
 }

--- a/test/strip-metadata.test.js
+++ b/test/strip-metadata.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+
+(async () => {
+  const stripImageMetadata = (await import('../third_party/strip-metadata.js')).default;
+
+  const bufWithExif = Buffer.from([
+    0xff, 0xd8,
+    0xff, 0xe1, 0x00, 0x06, 0x45, 0x78, 0x69, 0x66, 0x00, 0x00,
+    0xff, 0xda, 0x00, 0x00,
+    0x00,
+    0xff, 0xd9
+  ]);
+
+  assert(bufWithExif.indexOf('Exif') !== -1, 'Original should contain Exif');
+
+  const blob = new Blob([bufWithExif], { type: 'image/jpeg' });
+  const cleaned = await stripImageMetadata(blob);
+  const cleanedBuf = Buffer.from(await cleaned.arrayBuffer());
+
+  assert.strictEqual(cleanedBuf.indexOf('Exif'), -1, 'Exif should be stripped');
+  // Ensure JPEG markers remain
+  assert(cleanedBuf[0] === 0xff && cleanedBuf[1] === 0xd8, 'JPEG SOI preserved');
+  assert(cleanedBuf[cleanedBuf.length - 2] === 0xff && cleanedBuf[cleanedBuf.length - 1] === 0xd9, 'JPEG EOI preserved');
+  console.log('Metadata stripping test passed.');
+})();

--- a/third_party/strip-metadata.js
+++ b/third_party/strip-metadata.js
@@ -1,0 +1,35 @@
+export default async function stripImageMetadata(file) {
+  const buf = new Uint8Array(await file.arrayBuffer());
+  // Ensure JPEG SOI
+  if (buf[0] !== 0xff || buf[1] !== 0xd8) return file;
+  const segments = [];
+  let pos = 2;
+  while (pos < buf.length) {
+    if (buf[pos] !== 0xff) break;
+    const marker = buf[pos + 1];
+    if (marker === 0xda) { // Start of Scan
+      segments.push(buf.subarray(pos));
+      break;
+    }
+    const len = (buf[pos + 2] << 8) | buf[pos + 3];
+    const segmentEnd = pos + 4 + len;
+    const isExif = marker === 0xe1 &&
+      buf[pos + 4] === 0x45 &&
+      buf[pos + 5] === 0x78 &&
+      buf[pos + 6] === 0x69 &&
+      buf[pos + 7] === 0x66;
+    if (!isExif) {
+      segments.push(buf.subarray(pos, segmentEnd));
+    }
+    pos = segmentEnd;
+  }
+  const size = 2 + segments.reduce((n, s) => n + s.length, 0);
+  const out = new Uint8Array(size);
+  out[0] = 0xff; out[1] = 0xd8;
+  let offset = 2;
+  for (const seg of segments) {
+    out.set(seg, offset);
+    offset += seg.length;
+  }
+  return new Blob([out], { type: file.type });
+}


### PR DESCRIPTION
## Summary
- add small client-side helper to remove JPEG EXIF segments
- strip metadata from note attachment images before saving
- cover metadata stripping with a new unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9be46908c8331b8d859f673e4ed91