### PR TITLE
Secure collaboration handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Type commands into the input bar or directly in the terminal view. Use `help` to
 - `gdriveconfig <client_id> <api_key>` — store Google Drive credentials for backup
 - `themepreset <json>` — apply a theme preset from JSON
 - `themeexport [name]` — download current theme preset
-- `collab <session>` — join a collaboration channel and broadcast tasks/notes
+- `collab <session> <secret>` — join a collaboration channel with a shared secret and broadcast tasks/notes
 
 ## Feature Helpers
 
@@ -242,7 +242,7 @@ exportThemePreset('my-theme'); // downloads my-theme.json
 ### Collaboration Channel
 ```js
 import { startCollaboration } from './collaboration.js';
-const collab = startCollaboration('session1', 'shared-secret');
+const collab = await startCollaboration('session1', 'shared-secret');
 await collab.broadcast(); // sync current tasks/notes to other tabs with same session and secret
 ```
 

--- a/app.js
+++ b/app.js
@@ -1349,9 +1349,10 @@ cmd.backup = async (args)=>{
 let collabSession = null;
 cmd.collab = async (args)=>{
   const session = args[0];
-  if (!session) return println('usage: COLLAB <session>', 'error');
+  const secret = args[1];
+  if (!session || !secret) return println('usage: COLLAB <session> <secret>', 'error');
   const { startCollaboration } = await loadCollaboration();
-  collabSession = startCollaboration(session);
+  collabSession = await startCollaboration(session, secret);
   if (collabSession && collabSession.broadcast) collabSession.broadcast();
   println('collaboration started.', 'ok');
 };

--- a/collaboration.js
+++ b/collaboration.js
@@ -1,11 +1,14 @@
 import { getItems, getNotes, getMessages } from './features.js';
 
-function startCollaboration(sessionId, secret, saltBytes) {
-  const channel = new BroadcastChannel(`tl-collab-${sessionId}`);
+async function startCollaboration(sessionId, secret, saltBytes) {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(sessionId + secret));
+  const hashHex = Array.from(new Uint8Array(hashBuffer)).map(b => b.toString(16).padStart(2, '0')).join('');
+  const channel = new BroadcastChannel(`tl-collab-${hashHex}`);
   let salt = saltBytes ? new Uint8Array(saltBytes) : null;
   let keyPromise = null;
+  let handshakeComplete = false;
 
   function showSalt() {
     if (!salt) return;
@@ -39,23 +42,46 @@ function startCollaboration(sessionId, secret, saltBytes) {
     return keyPromise;
   }
 
+  async function encryptPayload(payload) {
+    const key = await getKey();
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encrypted = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      encoder.encode(JSON.stringify(payload))
+    );
+    return { cipher: Array.from(new Uint8Array(encrypted)), iv: Array.from(iv) };
+  }
+
+  async function sendHandshake() {
+    channel.postMessage(await encryptPayload({ type: 'handshake' }));
+  }
+
   channel.onmessage = async e => {
     try {
       if (e.data && e.data.salt && !salt) {
         salt = new Uint8Array(e.data.salt);
         showSalt();
         await getKey();
+        await sendHandshake();
         return;
       }
-      const key = await getKey();
       const { cipher, iv } = e.data || {};
       if (!cipher || !iv) return;
+      const key = await getKey();
       const decrypted = await crypto.subtle.decrypt(
         { name: 'AES-GCM', iv: new Uint8Array(iv) },
         key,
         new Uint8Array(cipher)
       );
       const data = JSON.parse(decoder.decode(decrypted));
+      if (data && data.type === 'handshake') {
+        const wasComplete = handshakeComplete;
+        handshakeComplete = true;
+        if (!wasComplete) await sendHandshake();
+        return;
+      }
+      if (!handshakeComplete) return;
       if (data && data.items && data.notes) {
         if (typeof saveItems === 'function') saveItems(data.items);
         if (typeof saveNotes === 'function') saveNotes(data.notes);
@@ -68,15 +94,11 @@ function startCollaboration(sessionId, secret, saltBytes) {
   };
 
   async function broadcast() {
-    const key = await getKey();
-    const iv = crypto.getRandomValues(new Uint8Array(12));
-    const payload = { items: getItems(), notes: getNotes(), messages: getMessages() };
-    const encrypted = await crypto.subtle.encrypt(
-      { name: 'AES-GCM', iv },
-      key,
-      encoder.encode(JSON.stringify(payload))
-    );
-    channel.postMessage({ cipher: Array.from(new Uint8Array(encrypted)), iv: Array.from(iv) });
+    if (!handshakeComplete) {
+      await sendHandshake();
+      return;
+    }
+    channel.postMessage(await encryptPayload({ items: getItems(), notes: getNotes(), messages: getMessages() }));
   }
 
   return { channel, broadcast, getSalt: () => Array.from(salt || []) };


### PR DESCRIPTION
## Summary
- Add secret parameter to `COLLAB` command and forward to collaboration module.
- Hash session and secret to generate unguessable BroadcastChannel names and require an encrypted handshake before syncing data.
- Document new `COLLAB <session> <secret>` syntax and async `startCollaboration` usage.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9be4aff3c8331adf5998abadecf06