### PR TITLE
Reset inactivity timer on modal input

### DIFF
--- a/app.js
+++ b/app.js
@@ -318,13 +318,19 @@ function resetInactivityTimer(){
   }, INACTIVITY_MS);
 }
 function startInactivityTimer(){
-  command.addEventListener('keydown', resetInactivityTimer);
-  command.addEventListener('pointerdown', resetInactivityTimer);
+  [command, modal].forEach(el => {
+    if (!el) return;
+    el.addEventListener('keydown', resetInactivityTimer);
+    el.addEventListener('pointerdown', resetInactivityTimer);
+  });
   resetInactivityTimer();
 }
 function stopInactivityTimer(){
-  command.removeEventListener('keydown', resetInactivityTimer);
-  command.removeEventListener('pointerdown', resetInactivityTimer);
+  [command, modal].forEach(el => {
+    if (!el) return;
+    el.removeEventListener('keydown', resetInactivityTimer);
+    el.removeEventListener('pointerdown', resetInactivityTimer);
+  });
   clearTimeout(inactivityTimer);
 }
 const modal = document.getElementById('modal');

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "build": "node build-manifest.js",
     "prepublishOnly": "npm audit",
-    "test": "node test/cache-header.test.js && node test/strip-metadata.test.js"
+    "test": "node test/cache-header.test.js && node test/strip-metadata.test.js && node test/inactivity.test.js"
   }
 }

--- a/test/inactivity.test.js
+++ b/test/inactivity.test.js
@@ -1,0 +1,99 @@
+const assert = require('assert');
+
+// Track timers so we can trigger them manually
+const timers = new Map();
+let nextTimerId = 1;
+global.setTimeout = (fn, ms) => {
+  const id = nextTimerId++;
+  timers.set(id, fn);
+  return id;
+};
+global.clearTimeout = (id) => {
+  timers.delete(id);
+};
+
+function makeElem() {
+  const handlers = {};
+  return {
+    addEventListener: (event, fn) => { handlers[event] = fn; },
+    removeEventListener: (event) => { delete handlers[event]; },
+    dispatchEvent: (evt) => {
+      const fn = handlers[evt.type];
+      if (fn) fn(evt);
+    },
+    classList: { add: () => {}, remove: () => {}, toggle: () => {} },
+    value: '',
+    focus: () => {},
+    blur: () => {},
+    innerHTML: '',
+    appendChild: () => {},
+    remove: () => {},
+    style: {},
+    dataset: {},
+    setAttribute: () => {},
+    click: () => {},
+    querySelector: () => null,
+  };
+}
+
+const outputs = [];
+const outputElem = { ...makeElem(), appendChild: (child) => outputs.push(child.textContent) };
+const commandElem = makeElem();
+const modalElem = makeElem();
+
+global.fetch = async () => ({ json: async () => ({}) });
+global.btoa = (str) => Buffer.from(str, 'binary').toString('base64');
+global.atob = (str) => Buffer.from(str, 'base64').toString('binary');
+global.document = {
+  addEventListener: () => {},
+  getElementById: (id) => {
+    if (id === 'output') return outputElem;
+    if (id === 'command') return commandElem;
+    if (id === 'modal') return modalElem;
+    return makeElem();
+  },
+  createElement: () => makeElem(),
+  body: { appendChild: () => {}, removeChild: () => {} },
+  documentElement: { style: {} },
+  visibilityState: 'visible',
+};
+global.window = { addEventListener: () => {}, requestAnimationFrame: () => {} };
+global.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+global.Notification = { permission: 'default', requestPermission: async () => 'granted' };
+global.navigator = {
+  serviceWorker: { addEventListener: () => {}, register: () => Promise.resolve(), ready: Promise.resolve(), controller: null },
+  share: async () => {},
+};
+
+(async () => {
+  const { cmd } = await import('../app.js');
+  let lockCalls = 0;
+  cmd.lock = () => { lockCalls++; };
+
+  // Initial timer
+  assert.strictEqual(timers.size, 1);
+  const id1 = Array.from(timers.keys())[0];
+
+  // Typing in command input should reset timer
+  commandElem.dispatchEvent({ type: 'keydown' });
+  assert.strictEqual(lockCalls, 0);
+  let ids = Array.from(timers.keys());
+  assert.strictEqual(ids.length, 1);
+  const id2 = ids[0];
+  assert.notStrictEqual(id2, id1);
+
+  // Typing in modal should also reset timer
+  modalElem.dispatchEvent({ type: 'keydown' });
+  assert.strictEqual(lockCalls, 0);
+  ids = Array.from(timers.keys());
+  assert.strictEqual(ids.length, 1);
+  const id3 = ids[0];
+  assert.notStrictEqual(id3, id2);
+
+  // Inactivity triggers lock
+  timers.get(id3)();
+  assert.strictEqual(lockCalls, 1);
+
+  console.log('Inactivity timer reset test passed.');
+})();
+


### PR DESCRIPTION
## Summary
- Reset inactivity timer when typing inside modal dialogs to avoid unintended locking
- Add regression test covering command input and modal activity scenarios
- Include new test in npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1afdd51a083319970e47212be5591