### PR TITLE
Add tests for inactivity reset across specialized modals

### DIFF
--- a/app.js
+++ b/app.js
@@ -318,7 +318,7 @@ function resetInactivityTimer(){
   }, INACTIVITY_MS);
 }
 function startInactivityTimer(){
-  [command, modal].forEach(el => {
+  [command, modal, noteModal, msgModal, passModal].forEach(el => {
     if (!el) return;
     el.addEventListener('keydown', resetInactivityTimer);
     el.addEventListener('pointerdown', resetInactivityTimer);
@@ -326,7 +326,7 @@ function startInactivityTimer(){
   resetInactivityTimer();
 }
 function stopInactivityTimer(){
-  [command, modal].forEach(el => {
+  [command, modal, noteModal, msgModal, passModal].forEach(el => {
     if (!el) return;
     el.removeEventListener('keydown', resetInactivityTimer);
     el.removeEventListener('pointerdown', resetInactivityTimer);

--- a/test/inactivity.test.js
+++ b/test/inactivity.test.js
@@ -40,6 +40,9 @@ const outputs = [];
 const outputElem = { ...makeElem(), appendChild: (child) => outputs.push(child.textContent) };
 const commandElem = makeElem();
 const modalElem = makeElem();
+const noteModalElem = makeElem();
+const msgModalElem = makeElem();
+const passModalElem = makeElem();
 
 global.fetch = async () => ({ json: async () => ({}) });
 global.btoa = (str) => Buffer.from(str, 'binary').toString('base64');
@@ -50,6 +53,9 @@ global.document = {
     if (id === 'output') return outputElem;
     if (id === 'command') return commandElem;
     if (id === 'modal') return modalElem;
+    if (id === 'note-modal') return noteModalElem;
+    if (id === 'msg-modal') return msgModalElem;
+    if (id === 'pass-modal') return passModalElem;
     return makeElem();
   },
   createElement: () => makeElem(),
@@ -90,8 +96,32 @@ global.navigator = {
   const id3 = ids[0];
   assert.notStrictEqual(id3, id2);
 
+  // Typing in note modal should reset timer
+  noteModalElem.dispatchEvent({ type: 'keydown' });
+  assert.strictEqual(lockCalls, 0);
+  ids = Array.from(timers.keys());
+  assert.strictEqual(ids.length, 1);
+  const id4 = ids[0];
+  assert.notStrictEqual(id4, id3);
+
+  // Typing in message modal should reset timer
+  msgModalElem.dispatchEvent({ type: 'keydown' });
+  assert.strictEqual(lockCalls, 0);
+  ids = Array.from(timers.keys());
+  assert.strictEqual(ids.length, 1);
+  const id5 = ids[0];
+  assert.notStrictEqual(id5, id4);
+
+  // Typing in password modal should reset timer
+  passModalElem.dispatchEvent({ type: 'keydown' });
+  assert.strictEqual(lockCalls, 0);
+  ids = Array.from(timers.keys());
+  assert.strictEqual(ids.length, 1);
+  const id6 = ids[0];
+  assert.notStrictEqual(id6, id5);
+
   // Inactivity triggers lock
-  timers.get(id3)();
+  timers.get(id6)();
   assert.strictEqual(lockCalls, 1);
 
   console.log('Inactivity timer reset test passed.');


### PR DESCRIPTION
## Summary
- ensure inactivity timer listens on note, message, and password modals
- add test coverage for modals resetting inactivity timer to prevent premature locking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c23b81701083318cb776c22f7a098a