### PR TITLE
Reset inactivity timer on all modals

### DIFF
--- a/app.js
+++ b/app.js
@@ -318,7 +318,7 @@ function resetInactivityTimer(){
   }, INACTIVITY_MS);
 }
 function startInactivityTimer(){
-  [command, modal].forEach(el => {
+  interactiveElements.forEach(el => {
     if (!el) return;
     el.addEventListener('keydown', resetInactivityTimer);
     el.addEventListener('pointerdown', resetInactivityTimer);
@@ -326,7 +326,7 @@ function startInactivityTimer(){
   resetInactivityTimer();
 }
 function stopInactivityTimer(){
-  [command, modal].forEach(el => {
+  interactiveElements.forEach(el => {
     if (!el) return;
     el.removeEventListener('keydown', resetInactivityTimer);
     el.removeEventListener('pointerdown', resetInactivityTimer);
@@ -1815,6 +1815,7 @@ const installBtn = document.getElementById('installBtn');
 const installStatus = document.getElementById('installStatus');
 const installHelp = document.getElementById('install-help');
 const installClose = document.getElementById('install-close');
+const interactiveElements = [command, modal, noteModal, msgModal, passModal, picModal, installHelp];
 let deferredPrompt = null;
 
 function setStatus(s){ if (installStatus) installStatus.textContent = s; }


### PR DESCRIPTION
## Summary
- Reset inactivity timer when user interacts with any modal by tracking interactive elements in a shared array
- Ensure listeners are added/removed across all modals to keep session active

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c23cd70084833188a2bf41c6401471