### PR TITLE
Add note modal inactivity coverage

### DIFF
--- a/app.js
+++ b/app.js
@@ -318,7 +318,7 @@ function resetInactivityTimer(){
   }, INACTIVITY_MS);
 }
 function startInactivityTimer(){
-  [command, modal].forEach(el => {
+  [command, modal, noteModal].forEach(el => {
     if (!el) return;
     el.addEventListener('keydown', resetInactivityTimer);
     el.addEventListener('pointerdown', resetInactivityTimer);
@@ -326,7 +326,7 @@ function startInactivityTimer(){
   resetInactivityTimer();
 }
 function stopInactivityTimer(){
-  [command, modal].forEach(el => {
+  [command, modal, noteModal].forEach(el => {
     if (!el) return;
     el.removeEventListener('keydown', resetInactivityTimer);
     el.removeEventListener('pointerdown', resetInactivityTimer);

--- a/test/inactivity.test.js
+++ b/test/inactivity.test.js
@@ -40,6 +40,7 @@ const outputs = [];
 const outputElem = { ...makeElem(), appendChild: (child) => outputs.push(child.textContent) };
 const commandElem = makeElem();
 const modalElem = makeElem();
+const noteModalElem = makeElem();
 
 global.fetch = async () => ({ json: async () => ({}) });
 global.btoa = (str) => Buffer.from(str, 'binary').toString('base64');
@@ -50,6 +51,7 @@ global.document = {
     if (id === 'output') return outputElem;
     if (id === 'command') return commandElem;
     if (id === 'modal') return modalElem;
+    if (id === 'note-modal') return noteModalElem;
     return makeElem();
   },
   createElement: () => makeElem(),
@@ -82,16 +84,24 @@ global.navigator = {
   const id2 = ids[0];
   assert.notStrictEqual(id2, id1);
 
-  // Typing in modal should also reset timer
-  modalElem.dispatchEvent({ type: 'keydown' });
+  // Typing in note modal should also reset timer
+  noteModalElem.dispatchEvent({ type: 'keydown' });
   assert.strictEqual(lockCalls, 0);
   ids = Array.from(timers.keys());
   assert.strictEqual(ids.length, 1);
   const id3 = ids[0];
   assert.notStrictEqual(id3, id2);
 
+  // Typing in modal should also reset timer
+  modalElem.dispatchEvent({ type: 'keydown' });
+  assert.strictEqual(lockCalls, 0);
+  ids = Array.from(timers.keys());
+  assert.strictEqual(ids.length, 1);
+  const id4 = ids[0];
+  assert.notStrictEqual(id4, id3);
+
   // Inactivity triggers lock
-  timers.get(id3)();
+  timers.get(id4)();
   assert.strictEqual(lockCalls, 1);
 
   console.log('Inactivity timer reset test passed.');


### PR DESCRIPTION
## Summary
- watch note modal in inactivity timer start/stop logic
- test note modal interactions reset inactivity timer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c23cd9253c83318bf4c9ff0891eae0